### PR TITLE
sociability with TalkBack (AccessibilityManager announcement when Crouton added to queue)

### DIFF
--- a/library/project.properties
+++ b/library/project.properties
@@ -12,5 +12,5 @@
 
 # Project target.
 
-target=android-14
+target=android-16
 android.library=true

--- a/sample/project.properties
+++ b/sample/project.properties
@@ -11,4 +11,4 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-14
+target=android-16


### PR DESCRIPTION
Added a TalkBack announcement for whenever a Crouton is added to queue, so that the Crouton text is read by TalkBack if TalkBack is turned ON.

Also found that Crouton doesn't work on API 3, due to, at least, the use of BitmapDrawable(resources, background). AccessibilityManager is only available from API 4, but I've put logic in to hopefully prevent problems should Crouton in future run on API 3.
