### PR TITLE
Crouton in ViewGroup (Crouton in fragment solution) + LifecycleCallback interface

### DIFF
--- a/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
@@ -57,6 +57,7 @@ public final class Crouton {
   private FrameLayout croutonView;
   private Animation inAnimation;
   private Animation outAnimation;
+  private LifecycleCallback lifecycleCallback = null;
 
   /**
    * Creates the {@link Crouton}.
@@ -429,6 +430,29 @@ public final class Crouton {
    */
   void detachViewGroup() {
     viewGroup = null;
+  }
+  
+  /**
+   * Removes the lifecycleCallback reference this {@link Crouton} is holding
+   */
+  void detachLifecycleCallback() {
+    lifecycleCallback = null;
+  }
+  
+  /**
+   * @param lifecycleCallback
+   *          Callback object for notable events in the life of a Crouton.
+   */
+  public Crouton setLifecycleCallback(LifecycleCallback lifecycleCallback) {
+	  this.lifecycleCallback = lifecycleCallback;
+	  return this;
+  }
+  
+  /**
+   * @return the lifecycleCallback
+   */
+  LifecycleCallback getLifecycleCallback() {
+	  return lifecycleCallback;
   }
 
   /**

--- a/library/src/de/keyboardsurfer/android/widget/crouton/LifecycleCallback.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/LifecycleCallback.java
@@ -1,0 +1,7 @@
+package de.keyboardsurfer.android.widget.crouton;
+
+public interface LifecycleCallback {
+	public void onDisplayed();
+	public void onRemoved();
+	//public void onCeasarDressing();
+}

--- a/library/src/de/keyboardsurfer/android/widget/crouton/Manager.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Manager.java
@@ -95,6 +95,9 @@ final class Manager extends Handler {
     if (!currentCrouton.isShowing()) {
       // Display the Crouton
       sendMessage(currentCrouton, Messages.ADD_CROUTON_TO_VIEW);
+      if(currentCrouton.getLifecycleCallback() != null) {
+    	  currentCrouton.getLifecycleCallback().onDisplayed();
+      }
     } else {
       sendMessageDelayed(currentCrouton, Messages.DISPLAY_CROUTON, calculateCroutonDuration(currentCrouton));
     }
@@ -160,6 +163,9 @@ final class Manager extends Handler {
 
       case Messages.REMOVE_CROUTON: {
         removeCrouton(crouton);
+        if(crouton.getLifecycleCallback() != null) {
+        	crouton.getLifecycleCallback().onRemoved();
+        }
         break;
       }
 
@@ -225,6 +231,10 @@ final class Manager extends Handler {
       if (removed != null) {
         removed.detachActivity();
         removed.detachViewGroup();
+        if(removed.getLifecycleCallback() != null) {
+        	removed.getLifecycleCallback().onRemoved();
+        }
+        removed.detachLifecycleCallback();
       }
 
       // Send a message to display the next crouton but delay it by the out


### PR DESCRIPTION
Added feature for displaying Crouton in a given ViewGroup (e.g. use this to display within a Fragment), currently only adds to first position in ViewGroup;

Added LifecycleCallback interface per Crouton, methods get called at notable moments in the lifetime of a Crouton;
