### PR TITLE
Bugfix for crouton.cancel()

### DIFF
--- a/library/src/de/keyboardsurfer/android/widget/crouton/Manager.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Manager.java
@@ -23,7 +23,6 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.Message;
 import android.support.v4.view.accessibility.AccessibilityEventCompat;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;


### PR DESCRIPTION
Prior to this fix, Manager.removeCroutonImmediately(Crouton crouton) would only remove currently showing Crouton if another instance of it existed in queue.

This fix helps my use-case whereby an 'undo' button is in Crouton, User presses on 'undo' button and Crouton needs to disappear immediately.

Also noticed that courton.isShowing() returns false in removeCroutonImmediately() even if it really is showing...strange...maybe croutonView object becomes out of sync with reality?
