### PR TITLE
Fix for crash when using an image in Crouton

### DIFF
--- a/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
@@ -755,6 +755,9 @@ public final class Crouton {
       RelativeLayout.LayoutParams.WRAP_CONTENT);
     imageParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT, RelativeLayout.TRUE);
     imageParams.addRule(RelativeLayout.CENTER_VERTICAL, RelativeLayout.TRUE);
+    
+    image.setLayoutParams(imageParams);
+    
     return image;
   }
 


### PR DESCRIPTION
Using Style.Builder to add an image (setImageResource() or .setImageDrawable() ) causes a crash when the Crouton is eventually inflated.

01-23 12:04:15.574: E/AndroidRuntime(4503): FATAL EXCEPTION: main
01-23 12:04:15.574: E/AndroidRuntime(4503): java.lang.NullPointerException
01-23 12:04:15.574: E/AndroidRuntime(4503):     at android.view.ViewGroup$LayoutParams.<init>(ViewGroup.java:5612)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at android.view.ViewGroup$MarginLayoutParams.<init>(ViewGroup.java:5838)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at android.widget.RelativeLayout$LayoutParams.<init>(RelativeLayout.java:1253)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at android.widget.RelativeLayout.generateLayoutParams(RelativeLayout.java:1013)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at android.view.ViewGroup.addViewInner(ViewGroup.java:3348)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at android.view.ViewGroup.addView(ViewGroup.java:3210)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at android.view.ViewGroup.addView(ViewGroup.java:3186)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at de.keyboardsurfer.android.widget.crouton.Crouton.initializeContentView(Crouton.java:682)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at de.keyboardsurfer.android.widget.crouton.Crouton.initializeCroutonView(Crouton.java:619)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at de.keyboardsurfer.android.widget.crouton.Crouton.getView(Crouton.java:607)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at de.keyboardsurfer.android.widget.crouton.Manager.addCroutonToView(Manager.java:191)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at de.keyboardsurfer.android.widget.crouton.Manager.handleMessage(Manager.java:160)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at android.os.Handler.dispatchMessage(Handler.java:99)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at android.os.Looper.loop(Looper.java:137)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at android.app.ActivityThread.main(ActivityThread.java:5039)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at java.lang.reflect.Method.invokeNative(Native Method)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at java.lang.reflect.Method.invoke(Method.java:511)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:793)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:560)
01-23 12:04:15.574: E/AndroidRuntime(4503):     at dalvik.system.NativeStart.main(Native Method)

Although, layout params are constructed for the resulting ImageView, it seems that they were not added to the ImageView !

Please find simple fix attached.

Cheers,
Damian
