### PR TITLE
Added Configuration - Seperating out duration from style 

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -17,24 +17,24 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <name>Crouton</name>
-  <description>Context sensitive notifications for Android</description>
-  <url>https://github.com/keyboardsurfer/Crouton</url>
-  <artifactId>crouton</artifactId>
-  <groupId>de.keyboardsurfer.android.widget</groupId>
-  <version>1.7</version>
-  <packaging>jar</packaging>
+    <name>Crouton</name>
+    <description>Context sensitive notifications for Android</description>
+    <url>https://github.com/keyboardsurfer/Crouton</url>
+    <artifactId>crouton</artifactId>
+    <groupId>de.keyboardsurfer.android.widget</groupId>
+    <version>${project.parent.version}</version>
+    <packaging>jar</packaging>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <android.version>4.1.1.4</android.version>
-    <android.version.platform>16</android.version.platform>
-  </properties>
+    <parent>
+        <groupId>de.keyboardsurfer.android.widget</groupId>
+        <artifactId>crouton-parent</artifactId>
+        <relativePath>../pom.xml</relativePath>
+        <version>1.8.0-SNAPSHOT</version>
+    </parent>
 
   <developers>
     <developer>
@@ -43,70 +43,75 @@
     </developer>
   </developers>
 
-  <licenses>
-    <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
+    <developers>
+        <developer>
+            <id>keyboardsurfer</id>
+            <name>Benjamin Weiss</name>
+        </developer>
+    </developers>
 
-  <scm>
-    <url>git@github.com:keyboardsurfer/Crouton.git</url>
-    <developerConnection>scm:git:git@github.com:keyboardsurfer/Crouton.git</developerConnection>
-    <connection>scm:git:git@github.com:keyboardsurfer/Crouton.git</connection>
-  </scm>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-  <dependencies>
-    <dependency>
-      <artifactId>android</artifactId>
-      <version>${android.version}</version>
-      <groupId>com.google.android</groupId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>support-v4</artifactId>
-      <version>r11</version>
-    </dependency>
-  </dependencies>
+    <scm>
+        <url>git@github.com:keyboardsurfer/Crouton.git</url>
+        <developerConnection>scm:git:git@github.com:keyboardsurfer/Crouton.git</developerConnection>
+        <connection>scm:git:git@github.com:keyboardsurfer/Crouton.git</connection>
+    </scm>
 
-  <build>
-    <sourceDirectory>src</sourceDirectory>
+    <dependencies>
+        <dependency>
+            <artifactId>android</artifactId>
+            <groupId>com.google.android</groupId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>android.support</groupId>
+            <artifactId>compatibility-v4</artifactId>
+        </dependency>
+    </dependencies>
 
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.jayway.maven.plugins.android.generation2</groupId>
-        <artifactId>android-maven-plugin</artifactId>
-        <version>3.5.0</version>
-      </plugin>
-    </plugins>
-  </build>
+    <build>
+        <sourceDirectory>src</sourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.jayway.maven.plugins.android.generation2</groupId>
+                <artifactId>android-maven-plugin</artifactId>
+                <version>3.5.0</version>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/library/src/de/keyboardsurfer/android/widget/crouton/Configuration.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Configuration.java
@@ -1,0 +1,66 @@
+package de.keyboardsurfer.android.widget.crouton;
+
+/**
+ * Created with Intellij with Android, BIZZBY product.
+ * See licencing for usage of this code.
+ * <p/>
+ * User: chris
+ * Date: 29/03/2013
+ * Time: 18:12
+ */
+public class Configuration
+{
+
+
+    public static final int DURATION_SHORT = 3000;
+    public static final int DURATION_LONG = 5000;
+    /**
+     * Display a {@link Crouton} for an infinite amount of time or
+     * until {@link de.keyboardsurfer.android.widget.crouton.Crouton#cancel()} has been called.
+     */
+    public static final int DURATION_INFINITE = -1;
+    /**
+     * The durationInMilliseconds the {@link Crouton} will be displayed in
+     * milliseconds.
+     */
+    public static final Configuration DEFAULT;
+
+    static
+    {
+        DEFAULT = new Builder().setDuration(DURATION_SHORT).build();
+    }
+
+    final int durationInMilliseconds;
+
+    private Configuration(Builder builder)
+    {
+        this.durationInMilliseconds = builder.durationInMilliseconds;
+    }
+
+    public static class Builder
+    {
+        private int durationInMilliseconds = DURATION_SHORT;
+
+        /**
+         * Set the durationInMilliseconds option of the {@link Crouton}.
+         *
+         * @param duration The durationInMilliseconds the crouton will be displayed
+         *                 {@link Crouton} in milliseconds.
+         * @return the {@link Builder}.
+         */
+        public Builder setDuration(int duration)
+        {
+            this.durationInMilliseconds = duration;
+
+            return this;
+        }
+
+        /**
+         * @return a configured {@link Style} object.
+         */
+        public Configuration build()
+        {
+            return new Configuration(this);
+        }
+    }
+}

--- a/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
@@ -50,776 +50,857 @@ import android.widget.TextView;
  * {@link android.app.Activity#onDestroy()} to avoid {@link Context} leaks.
  */
 public final class Crouton {
-  private static final int IMAGE_ID = 0x100;
-  private static final int TEXT_ID = 0x101;
-  private final CharSequence text;
-  private final Style style;
-  private final View customView;
+    private static final int IMAGE_ID = 0x100;
+    private static final int TEXT_ID = 0x101;
+    private final CharSequence text;
+    private final Style style;
+    private final View customView;
+    private Configuration configuration;
 
-  private OnClickListener onClickListener;
-  
-  private Activity activity;
-  private ViewGroup viewGroup;
-  private FrameLayout croutonView;
-  private Animation inAnimation;
-  private Animation outAnimation;
-  private LifecycleCallback lifecycleCallback = null;
+    private OnClickListener onClickListener;
 
-  /**
-   * Creates the {@link Crouton}.
-   *
-   * @param activity
-   *   The {@link Activity} that the {@link Crouton} should be attached
-   *   to.
-   * @param text
-   *   The text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   */
-  private Crouton(Activity activity, CharSequence text, Style style) {
-    if ((activity == null) || (text == null) || (style == null)) {
-      throw new IllegalArgumentException("Null parameters are not accepted");
+    private Activity activity;
+    private ViewGroup viewGroup;
+    private FrameLayout croutonView;
+    private Animation inAnimation;
+    private Animation outAnimation;
+    private LifecycleCallback lifecycleCallback = null;
+
+    /**
+     * Creates the {@link Crouton}.
+     *
+     * @param activity
+     *   The {@link Activity} that the {@link Crouton} should be attached
+     *   to.
+     * @param text
+     *   The text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     */
+    private Crouton(Activity activity, CharSequence text, Style style) {
+        if ((activity == null) || (text == null) || (style == null)) {
+            throw new IllegalArgumentException("Null parameters are not accepted");
+        }
+
+        this.activity = activity;
+        this.viewGroup = null;
+        this.text = text;
+        this.style = style;
+        this.customView = null;
+        this.configuration = new Configuration.Builder().build();
     }
 
-    this.activity = activity;
-    this.viewGroup = null;
-    this.text = text;
-    this.style = style;
-    this.customView = null;
-  }
+    /**
+     * Creates the {@link Crouton}.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param text
+     *   The text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     * @param viewGroup
+     *   The {@link ViewGroup} that this {@link Crouton} should be added to.
+     */
+    private Crouton(Activity activity, CharSequence text, Style style, ViewGroup viewGroup) {
+        if ((activity == null) || (text == null) || (style == null)) {
+            throw new IllegalArgumentException("Null parameters are not accepted");
+        }
 
-  /**
-   * Creates the {@link Crouton}.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param text
-   *   The text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   * @param viewGroup
-   *   The {@link ViewGroup} that this {@link Crouton} should be added to.
-   */
-  private Crouton(Activity activity, CharSequence text, Style style, ViewGroup viewGroup) {
-    if ((activity == null) || (text == null) || (style == null)) {
-      throw new IllegalArgumentException("Null parameters are not accepted");
+        this.activity = activity;
+        this.text = text;
+        this.style = style;
+        this.viewGroup = viewGroup;
+        this.customView = null;
+        this.configuration = new Configuration.Builder().build();
     }
 
-    this.activity = activity;
-    this.text = text;
-    this.style = style;
-    this.viewGroup = viewGroup;
-    this.customView = null;
-  }
+    /**
+     * Creates the {@link Crouton}.
+     *
+     * @param activity
+     *   The {@link Activity} that the {@link Crouton} should be attached
+     *   to.
+     * @param customView
+     *   The custom {@link View} to display
+     */
+    private Crouton(Activity activity, View customView) {
+        if ((activity == null) || (customView == null)) {
+            throw new IllegalArgumentException("Null parameters are not accepted");
+        }
 
-  /**
-   * Creates the {@link Crouton}.
-   *
-   * @param activity
-   *   The {@link Activity} that the {@link Crouton} should be attached
-   *   to.
-   * @param customView
-   *   The custom {@link View} to display
-   */
-  private Crouton(Activity activity, View customView) {
-    if ((activity == null) || (customView == null)) {
-      throw new IllegalArgumentException("Null parameters are not accepted");
+        this.activity = activity;
+        this.viewGroup = null;
+        this.customView = customView;
+        this.style = new Style.Builder().build();
+        this.text = null;
+        this.configuration = new Configuration.Builder().build();
     }
 
-    this.activity = activity;
-    this.viewGroup = null;
-    this.customView = customView;
-    this.style = new Style.Builder().build();
-    this.text = null;
-  }
-
-  /**
-   * Creates the {@link Crouton}.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param customView
-   *   The custom {@link View} to display
-   * @param viewGroup
-   *   The {@link ViewGroup} that this {@link Crouton} should be added to.
-   */
-  private Crouton(Activity activity, View customView, ViewGroup viewGroup) {
-    if ((activity == null) || (customView == null)) {
-      throw new IllegalArgumentException("Null parameters are not accepted");
+    /**
+     * Creates the {@link Crouton}.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param customView
+     *   The custom {@link View} to display
+     * @param viewGroup
+     *   The {@link ViewGroup} that this {@link Crouton} should be added to.
+     */
+    private Crouton(Activity activity, View customView, ViewGroup viewGroup) {
+        this(activity, customView, viewGroup, new Configuration.Builder().build());
     }
 
-    this.activity = activity;
-    this.customView = customView;
-    this.viewGroup = viewGroup;
-    this.style = new Style.Builder().build();
-    this.text = null;
-  }
-  
-  /**
-   * Creates a {@link Crouton} with provided text and style for a given
-   * activity.
-   *
-   * @param activity
-   *   The {@link Activity} that the {@link Crouton} should be attached
-   *   to.
-   * @param text
-   *   The text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   *
-   * @return The created {@link Crouton}.
-   */
-  public static Crouton makeText(Activity activity, CharSequence text, Style style) {
-    return new Crouton(activity, text, style);
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text and style for a given
-   * activity.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param text
-   *   The text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   * @param viewGroup
-   *   The {@link ViewGroup} that this {@link Crouton} should be added to.
-   *
-   * @return The created {@link Crouton}.
-   */
-  public static Crouton makeText(Activity activity, CharSequence text, Style style, ViewGroup viewGroup) {
-    return new Crouton(activity, text, style, viewGroup);
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text and style for a given
-   * activity.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param text
-   *   The text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   * @param viewGroupResId
-   *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
-   *
-   * @return The created {@link Crouton}.
-   */
-  public static Crouton makeText(Activity activity, CharSequence text, Style style, int viewGroupResId) {
-    return new Crouton(activity, text, style, (ViewGroup) activity.findViewById(viewGroupResId));
-  }
-
-
-  /**
-   * Creates a {@link Crouton} with provided text-resource and style for a given
-   * activity.
-   *
-   * @param activity
-   *   The {@link Activity} that the {@link Crouton} should be attached
-   *   to.
-   * @param textResourceId
-   *   The resource id of the text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   *
-   * @return The created {@link Crouton}.
-   */
-  public static Crouton makeText(Activity activity, int textResourceId, Style style) {
-    return makeText(activity, activity.getString(textResourceId), style);
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text-resource and style for a given
-   * activity.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param textResourceId
-   *   The resource id of the text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   * @param viewGroup
-   *   The {@link ViewGroup} that this {@link Crouton} should be added to.
-   *
-   * @return The created {@link Crouton}.
-   */
-  public static Crouton makeText(Activity activity, int textResourceId, Style style, ViewGroup viewGroup) {
-    return makeText(activity, activity.getString(textResourceId), style, viewGroup);
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text-resource and style for a given
-   * activity.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param textResourceId
-   *   The resource id of the text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   * @param viewGroupResId
-   *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
-   *
-   * @return The created {@link Crouton}.
-   */
-  public static Crouton makeText(Activity activity, int textResourceId, Style style, int viewGroupResId) {
-    return makeText(activity, activity.getString(textResourceId), style,
-      (ViewGroup) activity.findViewById(viewGroupResId));
-  }
-
-
-  /**
-   * Creates a {@link Crouton} with provided text-resource and style for a given
-   * activity.
-   *
-   * @param activity
-   *   The {@link Activity} that the {@link Crouton} should be attached
-   *   to.
-   * @param customView
-   *   The custom {@link View} to display
-   *
-   * @return The created {@link Crouton}.
-   */
-  public static Crouton make(Activity activity, View customView) {
-    return new Crouton(activity, customView);
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text-resource and style for a given
-   * activity.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param customView
-   *   The custom {@link View} to display
-   * @param viewGroup
-   *   The {@link ViewGroup} that this {@link Crouton} should be added to.
-   *
-   * @return The created {@link Crouton}.
-   */
-  public static Crouton make(Activity activity, View customView, ViewGroup viewGroup) {
-    return new Crouton(activity, customView, viewGroup);
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text-resource and style for a given
-   * activity.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param customView
-   *   The custom {@link View} to display
-   * @param viewGroupResId
-   *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
-   *
-   * @return The created {@link Crouton}.
-   */
-  public static Crouton make(Activity activity, View customView, int viewGroupResId) {
-    return new Crouton(activity, customView, (ViewGroup) activity.findViewById(viewGroupResId));
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text and style for a given activity
-   * and displays it directly.
-   *
-   * @param activity
-   *   The {@link android.app.Activity} that the {@link Crouton} should
-   *   be attached to.
-   * @param text
-   *   The text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   */
-  public static void showText(Activity activity, CharSequence text, Style style) {
-    makeText(activity, text, style).show();
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text and style for a given activity
-   * and displays it directly.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param text
-   *   The text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   * @param viewGroup
-   *   The {@link ViewGroup} that this {@link Crouton} should be added to.
-   */
-  public static void showText(Activity activity, CharSequence text, Style style, ViewGroup viewGroup) {
-    makeText(activity, text, style, viewGroup).show();
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text and style for a given activity
-   * and displays it directly.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param text
-   *   The text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   * @param viewGroupResId
-   *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
-   */
-  public static void showText(Activity activity, CharSequence text, Style style, int viewGroupResId) {
-    makeText(activity, text, style, (ViewGroup) activity.findViewById(viewGroupResId)).show();
-  }
-
-
-  /**
-   * Creates a {@link Crouton} with provided text and style for a given activity
-   * and displays it directly.
-   *
-   * @param activity
-   *   The {@link android.app.Activity} that the {@link Crouton} should
-   *   be attached to.
-   * @param customView
-   *   The custom {@link View} to display
-   */
-  public static void show(Activity activity, View customView) {
-    make(activity, customView).show();
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text and style for a given activity
-   * and displays it directly.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param customView
-   *   The custom {@link View} to display
-   * @param viewGroup
-   *   The {@link ViewGroup} that this {@link Crouton} should be added to.
-   */
-  public static void show(Activity activity, View customView, ViewGroup viewGroup) {
-    make(activity, customView, viewGroup).show();
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text and style for a given activity
-   * and displays it directly.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param customView
-   *   The custom {@link View} to display
-   * @param viewGroupResId
-   *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
-   */
-  public static void show(Activity activity, View customView, int viewGroupResId) {
-    make(activity, customView, viewGroupResId).show();
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text-resource and style for a given
-   * activity and displays it directly.
-   *
-   * @param activity
-   *   The {@link Activity} that the {@link Crouton} should be attached
-   *   to.
-   * @param textResourceId
-   *   The resource id of the text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   */
-  public static void showText(Activity activity, int textResourceId, Style style) {
-    showText(activity, activity.getString(textResourceId), style);
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text-resource and style for a given
-   * activity and displays it directly.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param textResourceId
-   *   The resource id of the text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   * @param viewGroup
-   *   The {@link ViewGroup} that this {@link Crouton} should be added to.
-   */
-  public static void showText(Activity activity, int textResourceId, Style style, ViewGroup viewGroup) {
-    showText(activity, activity.getString(textResourceId), style, viewGroup);
-  }
-
-  /**
-   * Creates a {@link Crouton} with provided text-resource and style for a given
-   * activity and displays it directly.
-   *
-   * @param activity
-   *   The {@link Activity} that represents the context in which the Crouton should exist.
-   * @param textResourceId
-   *   The resource id of the text you want to display.
-   * @param style
-   *   The style that this {@link Crouton} should be created with.
-   * @param viewGroupResId
-   *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
-   */
-  public static void showText(Activity activity, int textResourceId, Style style, int viewGroupResId) {
-    showText(activity, activity.getString(textResourceId), style, viewGroupResId);
-  }
-
-  /**
-   * Allows hiding of a previously displayed {@link Crouton}.
-   * @param crouton The {@link Crouton} you want to hide.
-   */
-  public static void hide(Crouton crouton) {
-    Manager.getInstance().removeCrouton(crouton);
-  }
-
-  /**
-   * Cancels all queued {@link Crouton}s. If there is a {@link Crouton}
-   * displayed currently, it will be the last one displayed.
-   */
-  public static void cancelAllCroutons() {
-    Manager.getInstance().clearCroutonQueue();
-  }
-
-  /**
-   * Clears (and removes from {@link Activity}'s content view, if necessary) all
-   * croutons for the provided activity
-   *
-   * @param activity
-   *   - The {@link Activity} to clear the croutons for.
-   */
-  public static void clearCroutonsForActivity(Activity activity) {
-    Manager.getInstance().clearCroutonsForActivity(activity);
-  }
-
-  /**
-   * Cancels a {@link Crouton} immediately.
-   */
-  public void cancel() {
-    Manager manager = Manager.getInstance();
-    manager.removeCroutonImmediately(this);
-  }
-
-  /**
-   * Displays the {@link Crouton}. If there's another {@link Crouton} visible at
-   * the time, this {@link Crouton} will be displayed afterwards.
-   */
-  public void show() {
-    Manager.getInstance().add(this);
-  }
-
-  public Animation getInAnimation() {
-    if ((null == this.inAnimation) && (null != this.activity)) {
-      if (getStyle().inAnimationResId > 0) {
-        this.inAnimation = AnimationUtils.loadAnimation(getActivity(), getStyle().inAnimationResId);
-      } else {
-        this.inAnimation = DefaultAnimationsBuilder.buildDefaultSlideInDownAnimation();
-      }
+    /**
+     * Creates the {@link Crouton}.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param customView
+     *   The custom {@link View} to display
+     * @param viewGroup
+     *   The {@link ViewGroup} that this {@link Crouton} should be added to.
+     * @param configuration
+     *   The configuration for this crouton
+     */
+    private Crouton(Activity activity, View customView, ViewGroup viewGroup, Configuration configuration)
+    {
+        if ((activity == null) || (customView == null)) {
+            throw new IllegalArgumentException("Null parameters are not accepted");
+        }
+        this.activity = activity;
+        this.customView = customView;
+        this.viewGroup = viewGroup;
+        this.style = new Style.Builder().build();
+        this.configuration = configuration;
+        this.text = null;
     }
 
-    return inAnimation;
-  }
-
-  public Animation getOutAnimation() {
-    if ((null == this.outAnimation) && (null != this.activity)) {
-      if (getStyle().outAnimationResId > 0) {
-        this.outAnimation = AnimationUtils.loadAnimation(getActivity(), getStyle().outAnimationResId);
-      } else {
-        this.outAnimation = DefaultAnimationsBuilder.buildDefaultSlideOutUpAnimation();
-      }
+    /**
+     * Creates a {@link Crouton} with provided text and style for a given
+     * activity.
+     *
+     * @param activity
+     *   The {@link Activity} that the {@link Crouton} should be attached
+     *   to.
+     * @param text
+     *   The text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     *
+     * @return The created {@link Crouton}.
+     */
+    public static Crouton makeText(Activity activity, CharSequence text, Style style) {
+        return new Crouton(activity, text, style);
     }
 
-    return outAnimation;
-  }
-
-  /**
-   * @param lifecycleCallback
-   *   Callback object for notable events in the life of a Crouton.
-   */
-  public void setLifecycleCallback(LifecycleCallback lifecycleCallback) {
-    this.lifecycleCallback = lifecycleCallback;
-  }
-
-  /**
-   * Convenience method to get the license text for embedding within your application.
-   * @return 
-   *     The license text.
-   */
-  public String getLicenseText() {
-    return "This application uses the Crouton library.\n\n" +
-      "Copyright 2012 - 2013 Benjamin Weiss \n" +
-      "Copyright 2012 Neofonie Mobile GmbH\n" +
-      "\n" +
-      "Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
-      "you may not use this file except in compliance with the License.\n" +
-      "You may obtain a copy of the License at\n" +
-      "\n" +
-      "   http://www.apache.org/licenses/LICENSE-2.0\n" +
-      "\n" +
-      "Unless required by applicable law or agreed to in writing, software\n" +
-      "distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
-      "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
-      "See the License for the specific language governing permissions and\n" +
-      "limitations under the License.";
-  }
-
-  /**
-   * Allows setting of an {@link OnClickListener} directly to a {@link Crouton} without having to use a custom view.
-   * @param onClickListener The {@link OnClickListener} to set.
-   * @return this {@link Crouton}.
-   */
-  public Crouton setOnClickListener(OnClickListener onClickListener){
-    this.onClickListener = onClickListener;
-    return this;
-  }
-
-  /**
-   * @return <code>true</code> if the {@link Crouton} is being displayed, else
-   *         <code>false</code>.
-   */
-  boolean isShowing() {
-    return (null != activity) && (null != croutonView) && (null != croutonView.getParent());
-  }
-
-  /**
-   * Removes the activity reference this {@link Crouton} is holding
-   */
-  void detachActivity() {
-    activity = null;
-  }
-
-  /**
-   * Removes the viewGroup reference this {@link Crouton} is holding
-   */
-  void detachViewGroup() {
-    viewGroup = null;
-  }
-
-  /**
-   * Removes the lifecycleCallback reference this {@link Crouton} is holding
-   */
-  void detachLifecycleCallback() {
-    lifecycleCallback = null;
-  }
-
-  /**
-   * @return the lifecycleCallback
-   */
-  LifecycleCallback getLifecycleCallback() {
-    return lifecycleCallback;
-  }
-
-  /**
-   * @return the style
-   */
-  Style getStyle() {
-    return style;
-  }
-
-  /**
-   * @return the activity
-   */
-  Activity getActivity() {
-    return activity;
-  }
-
-  /**
-   * @return the viewGroup
-   */
-  ViewGroup getViewGroup() {
-    return viewGroup;
-  }
-
-  /**
-   * @return the text
-   */
-  CharSequence getText() {
-    return text;
-  }
-
-  /**
-   * @return the view
-   */
-  View getView() {
-    // return the custom view if one exists
-    if (null != this.customView) {
-      return this.customView;
+    /**
+     * Creates a {@link Crouton} with provided text and style for a given
+     * activity.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param text
+     *   The text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     * @param viewGroup
+     *   The {@link ViewGroup} that this {@link Crouton} should be added to.
+     *
+     * @return The created {@link Crouton}.
+     */
+    public static Crouton makeText(Activity activity, CharSequence text, Style style, ViewGroup viewGroup) {
+        return new Crouton(activity, text, style, viewGroup);
     }
 
-    // if already setup return the view
-    if (null == this.croutonView) {
-      initializeCroutonView();
+    /**
+     * Creates a {@link Crouton} with provided text and style for a given
+     * activity.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param text
+     *   The text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     * @param viewGroupResId
+     *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
+     *
+     * @return The created {@link Crouton}.
+     */
+    public static Crouton makeText(Activity activity, CharSequence text, Style style, int viewGroupResId) {
+        return new Crouton(activity, text, style, (ViewGroup) activity.findViewById(viewGroupResId));
     }
 
-    return croutonView;
-  }
 
-  private void initializeCroutonView() {
-    Resources resources = this.activity.getResources();
-
-    this.croutonView = initializeCroutonViewGroup(resources);
-
-    // create content view
-    RelativeLayout contentView = initializeContentView(resources);
-    this.croutonView.addView(contentView);
-  }
-
-  private FrameLayout initializeCroutonViewGroup(Resources resources) {
-    FrameLayout croutonView = new FrameLayout(this.activity);
-
-    if(null != onClickListener)
-    	croutonView.setOnClickListener(onClickListener);
-    
-    final int height;
-    if (this.style.heightDimensionResId > 0) {
-      height = resources.getDimensionPixelSize(this.style.heightDimensionResId);
-    } else {
-      height = this.style.heightInPixels;
+    /**
+     * Creates a {@link Crouton} with provided text-resource and style for a given
+     * activity.
+     *
+     * @param activity
+     *   The {@link Activity} that the {@link Crouton} should be attached
+     *   to.
+     * @param textResourceId
+     *   The resource id of the text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     *
+     * @return The created {@link Crouton}.
+     */
+    public static Crouton makeText(Activity activity, int textResourceId, Style style) {
+        return makeText(activity, activity.getString(textResourceId), style);
     }
 
-    final int width;
-    if (this.style.widthDimensionResId > 0) {
-      width = resources.getDimensionPixelSize(this.style.widthDimensionResId);
-    } else {
-      width = this.style.widthInPixels;
+    /**
+     * Creates a {@link Crouton} with provided text-resource and style for a given
+     * activity.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param textResourceId
+     *   The resource id of the text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     * @param viewGroup
+     *   The {@link ViewGroup} that this {@link Crouton} should be added to.
+     *
+     * @return The created {@link Crouton}.
+     */
+    public static Crouton makeText(Activity activity, int textResourceId, Style style, ViewGroup viewGroup) {
+        return makeText(activity, activity.getString(textResourceId), style, viewGroup);
     }
 
-    croutonView.setLayoutParams(
-      new FrameLayout.LayoutParams(width != 0 ? width : FrameLayout.LayoutParams.MATCH_PARENT, height));
-
-    // set background
-    if (this.style.backgroundColorValue != -1) {
-      croutonView.setBackgroundColor(this.style.backgroundColorValue);
-    } else {
-      croutonView.setBackgroundColor(resources.getColor(this.style.backgroundColorResourceId));
+    /**
+     * Creates a {@link Crouton} with provided text-resource and style for a given
+     * activity.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param textResourceId
+     *   The resource id of the text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     * @param viewGroupResId
+     *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
+     *
+     * @return The created {@link Crouton}.
+     */
+    public static Crouton makeText(Activity activity, int textResourceId, Style style, int viewGroupResId) {
+        return makeText(activity, activity.getString(textResourceId), style,
+                (ViewGroup) activity.findViewById(viewGroupResId));
     }
 
-    // set the background drawable if set. This will override the background
-    // color.
-    if (this.style.backgroundDrawableResourceId != 0) {
-      Bitmap background = BitmapFactory.decodeResource(resources, this.style.backgroundDrawableResourceId);
-      BitmapDrawable drawable = new BitmapDrawable(resources, background);
-      if (this.style.isTileEnabled) {
-        drawable.setTileModeXY(Shader.TileMode.REPEAT, Shader.TileMode.REPEAT);
-      }
-      croutonView.setBackgroundDrawable(drawable);
-    }
-    return croutonView;
-  }
 
-  private RelativeLayout initializeContentView(final Resources resources) {
-    RelativeLayout contentView = new RelativeLayout(this.activity);
-    contentView.setLayoutParams(new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT,
-      RelativeLayout.LayoutParams.WRAP_CONTENT));
-
-    // set padding
-    int padding = this.style.paddingInPixels;
-
-    // if a padding dimension has been set, this will overwrite any padding
-    // in pixels
-    if (this.style.paddingDimensionResId > 0) {
-      padding = resources.getDimensionPixelSize(this.style.paddingDimensionResId);
-    }
-    contentView.setPadding(padding, padding, padding, padding);
-
-    // only setup image if one is requested
-    ImageView image = null;
-    if ((null != this.style.imageDrawable) || (0 != this.style.imageResId)) {
-      image = initializeImageView();
-      contentView.addView(image, image.getLayoutParams());
+    /**
+     * Creates a {@link Crouton} with provided text-resource and style for a given
+     * activity.
+     *
+     * @param activity
+     *   The {@link Activity} that the {@link Crouton} should be attached
+     *   to.
+     * @param customView
+     *   The custom {@link View} to display
+     *
+     * @return The created {@link Crouton}.
+     */
+    public static Crouton make(Activity activity, View customView) {
+        return new Crouton(activity, customView);
     }
 
-    TextView text = initializeTextView(resources);
-
-    RelativeLayout.LayoutParams textParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT,
-      RelativeLayout.LayoutParams.WRAP_CONTENT);
-    if (null != image) {
-      textParams.addRule(RelativeLayout.RIGHT_OF, image.getId());
-    }
-    contentView.addView(text, textParams);
-    return contentView;
-  }
-
-  private TextView initializeTextView(final Resources resources) {
-    TextView text = new TextView(this.activity);
-    text.setId(TEXT_ID);
-    text.setText(this.text);
-    text.setTypeface(Typeface.DEFAULT_BOLD);
-    text.setGravity(this.style.gravity);
-    
-    // set the text color if set
-    if (this.style.textColorResourceId != 0) {
-      text.setTextColor(resources.getColor(this.style.textColorResourceId));
+    /**
+     * Creates a {@link Crouton} with provided text-resource and style for a given
+     * activity.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param customView
+     *   The custom {@link View} to display
+     * @param viewGroup
+     *   The {@link ViewGroup} that this {@link Crouton} should be added to.
+     *
+     * @return The created {@link Crouton}.
+     */
+    public static Crouton make(Activity activity, View customView, ViewGroup viewGroup) {
+        return new Crouton(activity, customView, viewGroup);
     }
 
-    // Set the text size. If the user has set a text size and text
-    // appearance, the text size in the text appearance
-    // will override this.
-    if (this.style.textSize != 0) {
-      text.setTextSize(TypedValue.COMPLEX_UNIT_SP, this.style.textSize);
+    /**
+     * Creates a {@link Crouton} with provided text-resource and style for a given
+     * activity.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param customView
+     *   The custom {@link View} to display
+     * @param viewGroupResId
+     *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
+     *
+     * @return The created {@link Crouton}.
+     */
+    public static Crouton make(Activity activity, View customView, int viewGroupResId) {
+        return new Crouton(activity, customView, (ViewGroup) activity.findViewById(viewGroupResId));
     }
 
-    // Setup the shadow if requested
-    if (this.style.textShadowColorResId != 0) {
-      initializeTextViewShadow(resources, text);
+    /**
+     * Creates a {@link Crouton} with provided text-resource and style for a given
+     * activity.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param customView
+     *   The custom {@link View} to display
+     * @param viewGroupResId
+     *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
+     * @param configuration
+     *   The configuration of
+     *
+     * @return The created {@link Crouton}.
+     */
+    public static Crouton make(Activity activity, View customView, int viewGroupResId, Configuration configuration) {
+        return new Crouton(activity, customView, (ViewGroup) activity.findViewById(viewGroupResId)).setConfiguration(configuration);
     }
 
-    // Set the text appearance
-    if (this.style.textAppearanceResId != 0) {
-      text.setTextAppearance(this.activity, this.style.textAppearanceResId);
-    }
-    return text;
-  }
-
-  private void initializeTextViewShadow(final Resources resources, final TextView text) {
-    int textShadowColor = resources.getColor(this.style.textShadowColorResId);
-    float textShadowRadius = this.style.textShadowRadius;
-    float textShadowDx = this.style.textShadowDx;
-    float textShadowDy = this.style.textShadowDy;
-    text.setShadowLayer(textShadowRadius, textShadowDx, textShadowDy, textShadowColor);
-  }
-
-  private ImageView initializeImageView() {
-    ImageView image;
-    image = new ImageView(this.activity);
-    image.setId(IMAGE_ID);
-    image.setAdjustViewBounds(true);
-    image.setScaleType(this.style.imageScaleType);
-
-    // set the image drawable if not null
-    if (null != this.style.imageDrawable) {
-      image.setImageDrawable(this.style.imageDrawable);
+    /**
+     * Creates a {@link Crouton} with provided text and style for a given activity
+     * and displays it directly.
+     *
+     * @param activity
+     *   The {@link android.app.Activity} that the {@link Crouton} should
+     *   be attached to.
+     * @param text
+     *   The text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     */
+    public static void showText(Activity activity, CharSequence text, Style style) {
+        makeText(activity, text, style).show();
     }
 
-    // set the image resource if not 0. This will overwrite the drawable
-    // if both are set
-    if (this.style.imageResId != 0) {
-      image.setImageResource(this.style.imageResId);
+    /**
+     * Creates a {@link Crouton} with provided text and style for a given activity
+     * and displays it directly.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param text
+     *   The text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     * @param viewGroup
+     *   The {@link ViewGroup} that this {@link Crouton} should be added to.
+     */
+    public static void showText(Activity activity, CharSequence text, Style style, ViewGroup viewGroup) {
+        makeText(activity, text, style, viewGroup).show();
     }
 
-    RelativeLayout.LayoutParams imageParams = new RelativeLayout.LayoutParams(
-      RelativeLayout.LayoutParams.WRAP_CONTENT,
-      RelativeLayout.LayoutParams.WRAP_CONTENT);
-    imageParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT, RelativeLayout.TRUE);
-    imageParams.addRule(RelativeLayout.CENTER_VERTICAL, RelativeLayout.TRUE);
-    
-    image.setLayoutParams(imageParams);
-    
-    return image;
-  }
+    /**
+     * Creates a {@link Crouton} with provided text and style for a given activity
+     * and displays it directly.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param text
+     *   The text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     * @param viewGroupResId
+     *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
+     */
+    public static void showText(Activity activity, CharSequence text, Style style, int viewGroupResId) {
+        makeText(activity, text, style, (ViewGroup) activity.findViewById(viewGroupResId)).show();
+    }
+    /**
+     * Creates a {@link Crouton} with provided text and style for a given activity
+     * and displays it directly.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param text
+     *   The text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     * @param viewGroupResId
+     *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
+     * @param configuration
+     *   The configuration to setup none visual configurations
+     */
+    public static void showText(Activity activity, CharSequence text, Style style, int viewGroupResId, Configuration configuration) {
+        makeText(activity, text, style, (ViewGroup) activity.findViewById(viewGroupResId)).setConfiguration(configuration).show();
+    }
 
-  @Override
-  public String toString() {
-    return "Crouton{" +
-      "text=" + text +
-      ", style=" + style +
-      ", customView=" + customView +
-      ", activity=" + activity +
-      ", viewGroup=" + viewGroup +
-      ", croutonView=" + croutonView +
-      ", inAnimation=" + inAnimation +
-      ", outAnimation=" + outAnimation +
-      ", lifecycleCallback=" + lifecycleCallback +
-      '}';
-  }
+
+    /**
+     * Creates a {@link Crouton} with provided text and style for a given activity
+     * and displays it directly.
+     *
+     * @param activity
+     *   The {@link android.app.Activity} that the {@link Crouton} should
+     *   be attached to.
+     * @param customView
+     *   The custom {@link View} to display
+     */
+    public static void show(Activity activity, View customView) {
+        make(activity, customView).show();
+    }
+
+    /**
+     * Creates a {@link Crouton} with provided text and style for a given activity
+     * and displays it directly.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param customView
+     *   The custom {@link View} to display
+     * @param viewGroup
+     *   The {@link ViewGroup} that this {@link Crouton} should be added to.
+     */
+    public static void show(Activity activity, View customView, ViewGroup viewGroup) {
+        make(activity, customView, viewGroup).show();
+    }
+
+    /**
+     * Creates a {@link Crouton} with provided text and style for a given activity
+     * and displays it directly.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param customView
+     *   The custom {@link View} to display
+     * @param viewGroupResId
+     *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
+     */
+    public static void show(Activity activity, View customView, int viewGroupResId) {
+        make(activity, customView, viewGroupResId).show();
+    }
+
+    /**
+     * Creates a {@link Crouton} with provided text-resource and style for a given
+     * activity and displays it directly.
+     *
+     * @param activity
+     *   The {@link Activity} that the {@link Crouton} should be attached
+     *   to.
+     * @param textResourceId
+     *   The resource id of the text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     */
+    public static void showText(Activity activity, int textResourceId, Style style) {
+        showText(activity, activity.getString(textResourceId), style);
+    }
+
+    /**
+     * Creates a {@link Crouton} with provided text-resource and style for a given
+     * activity and displays it directly.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param textResourceId
+     *   The resource id of the text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     * @param viewGroup
+     *   The {@link ViewGroup} that this {@link Crouton} should be added to.
+     */
+    public static void showText(Activity activity, int textResourceId, Style style, ViewGroup viewGroup) {
+        showText(activity, activity.getString(textResourceId), style, viewGroup);
+    }
+
+    /**
+     * Creates a {@link Crouton} with provided text-resource and style for a given
+     * activity and displays it directly.
+     *
+     * @param activity
+     *   The {@link Activity} that represents the context in which the Crouton should exist.
+     * @param textResourceId
+     *   The resource id of the text you want to display.
+     * @param style
+     *   The style that this {@link Crouton} should be created with.
+     * @param viewGroupResId
+     *   The resource id of the {@link ViewGroup} that this {@link Crouton} should be added to.
+     */
+    public static void showText(Activity activity, int textResourceId, Style style, int viewGroupResId) {
+        showText(activity, activity.getString(textResourceId), style, viewGroupResId);
+    }
+
+    /**
+     * Allows hiding of a previously displayed {@link Crouton}.
+     * @param crouton The {@link Crouton} you want to hide.
+     */
+    public static void hide(Crouton crouton) {
+        Manager.getInstance().removeCrouton(crouton);
+    }
+
+    /**
+     * Cancels all queued {@link Crouton}s. If there is a {@link Crouton}
+     * displayed currently, it will be the last one displayed.
+     */
+    public static void cancelAllCroutons() {
+        Manager.getInstance().clearCroutonQueue();
+    }
+
+    /**
+     * Clears (and removes from {@link Activity}'s content view, if necessary) all
+     * croutons for the provided activity
+     *
+     * @param activity
+     *   - The {@link Activity} to clear the croutons for.
+     */
+    public static void clearCroutonsForActivity(Activity activity) {
+        Manager.getInstance().clearCroutonsForActivity(activity);
+    }
+
+    /**
+     * Cancels a {@link Crouton} immediately.
+     */
+    public void cancel() {
+        Manager manager = Manager.getInstance();
+        manager.removeCroutonImmediately(this);
+    }
+
+    /**
+     * Displays the {@link Crouton}. If there's another {@link Crouton} visible at
+     * the time, this {@link Crouton} will be displayed afterwards.
+     */
+    public void show() {
+        Manager.getInstance().add(this);
+    }
+
+    public Animation getInAnimation() {
+        if ((null == this.inAnimation) && (null != this.activity)) {
+            if (getStyle().inAnimationResId > 0) {
+                this.inAnimation = AnimationUtils.loadAnimation(getActivity(), getStyle().inAnimationResId);
+            } else {
+                this.inAnimation = DefaultAnimationsBuilder.buildDefaultSlideInDownAnimation();
+            }
+        }
+
+        return inAnimation;
+    }
+
+    public Animation getOutAnimation() {
+        if ((null == this.outAnimation) && (null != this.activity)) {
+            if (getStyle().outAnimationResId > 0) {
+                this.outAnimation = AnimationUtils.loadAnimation(getActivity(), getStyle().outAnimationResId);
+            } else {
+                this.outAnimation = DefaultAnimationsBuilder.buildDefaultSlideOutUpAnimation();
+            }
+        }
+
+        return outAnimation;
+    }
+
+    /**
+     * @param lifecycleCallback
+     *   Callback object for notable events in the life of a Crouton.
+     */
+    public void setLifecycleCallback(LifecycleCallback lifecycleCallback) {
+        this.lifecycleCallback = lifecycleCallback;
+    }
+
+    /**
+     * Convenience method to get the license text for embedding within your application.
+     * @return
+     *     The license text.
+     */
+    public String getLicenseText() {
+        return "This application uses the Crouton library.\n\n" +
+                "Copyright 2012 - 2013 Benjamin Weiss \n" +
+                "Copyright 2012 Neofonie Mobile GmbH\n" +
+                "\n" +
+                "Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
+                "you may not use this file except in compliance with the License.\n" +
+                "You may obtain a copy of the License at\n" +
+                "\n" +
+                "   http://www.apache.org/licenses/LICENSE-2.0\n" +
+                "\n" +
+                "Unless required by applicable law or agreed to in writing, software\n" +
+                "distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
+                "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
+                "See the License for the specific language governing permissions and\n" +
+                "limitations under the License.";
+    }
+
+    /**
+     * Allows setting of an {@link OnClickListener} directly to a {@link Crouton} without having to use a custom view.
+     * @param onClickListener The {@link OnClickListener} to set.
+     * @return this {@link Crouton}.
+     */
+    public Crouton setOnClickListener(OnClickListener onClickListener){
+        this.onClickListener = onClickListener;
+        return this;
+    }
+
+    /**
+     * Set the configuration on this crouton, idea being you can modify the none visual aspects pre showing it.
+     *
+     * @param configuration a configuration build using {@link Configuration.Builder}
+     * @return this {@link Crouton}
+     */
+    public Crouton setConfiguration(final Configuration configuration) {
+        if(configuration != null){
+            this.configuration = configuration;
+        }
+        return this;
+    }
+
+    /**
+     * @return <code>true</code> if the {@link Crouton} is being displayed, else
+     *         <code>false</code>.
+     */
+    boolean isShowing() {
+        return (null != activity) && (null != croutonView) && (null != croutonView.getParent());
+    }
+
+    /**
+     * Removes the activity reference this {@link Crouton} is holding
+     */
+    void detachActivity() {
+        activity = null;
+    }
+
+    /**
+     * Removes the viewGroup reference this {@link Crouton} is holding
+     */
+    void detachViewGroup() {
+        viewGroup = null;
+    }
+
+    /**
+     * Removes the lifecycleCallback reference this {@link Crouton} is holding
+     */
+    void detachLifecycleCallback() {
+        lifecycleCallback = null;
+    }
+
+    /**
+     * @return the lifecycleCallback
+     */
+    LifecycleCallback getLifecycleCallback() {
+        return lifecycleCallback;
+    }
+
+    /**
+     * @return the style
+     */
+    Style getStyle() {
+        return style;
+    }
+
+    /**
+     * @return the crouton style
+     */
+    Configuration getConfiguration()
+    {
+        return configuration;
+    }
+
+    /**
+     * @return the activity
+     */
+    Activity getActivity() {
+        return activity;
+    }
+
+    /**
+     * @return the viewGroup
+     */
+    ViewGroup getViewGroup() {
+        return viewGroup;
+    }
+
+    /**
+     * @return the text
+     */
+    CharSequence getText() {
+        return text;
+    }
+
+    /**
+     * @return the view
+     */
+    View getView() {
+        // return the custom view if one exists
+        if (null != this.customView) {
+            return this.customView;
+        }
+
+        // if already setup return the view
+        if (null == this.croutonView) {
+            initializeCroutonView();
+        }
+
+        return croutonView;
+    }
+
+    private void initializeCroutonView() {
+        Resources resources = this.activity.getResources();
+
+        this.croutonView = initializeCroutonViewGroup(resources);
+
+        // create content view
+        RelativeLayout contentView = initializeContentView(resources);
+        this.croutonView.addView(contentView);
+    }
+
+    private FrameLayout initializeCroutonViewGroup(Resources resources) {
+        FrameLayout croutonView = new FrameLayout(this.activity);
+
+        if(null != onClickListener)
+            croutonView.setOnClickListener(onClickListener);
+
+        final int height;
+        if (this.style.heightDimensionResId > 0) {
+            height = resources.getDimensionPixelSize(this.style.heightDimensionResId);
+        } else {
+            height = this.style.heightInPixels;
+        }
+
+        final int width;
+        if (this.style.widthDimensionResId > 0) {
+            width = resources.getDimensionPixelSize(this.style.widthDimensionResId);
+        } else {
+            width = this.style.widthInPixels;
+        }
+
+        croutonView.setLayoutParams(
+                new FrameLayout.LayoutParams(width != 0 ? width : FrameLayout.LayoutParams.MATCH_PARENT, height));
+
+        // set background
+        if (this.style.backgroundColorValue != -1) {
+            croutonView.setBackgroundColor(this.style.backgroundColorValue);
+        } else {
+            croutonView.setBackgroundColor(resources.getColor(this.style.backgroundColorResourceId));
+        }
+
+        // set the background drawable if set. This will override the background
+        // color.
+        if (this.style.backgroundDrawableResourceId != 0) {
+            Bitmap background = BitmapFactory.decodeResource(resources, this.style.backgroundDrawableResourceId);
+            BitmapDrawable drawable = new BitmapDrawable(resources, background);
+            if (this.style.isTileEnabled) {
+                drawable.setTileModeXY(Shader.TileMode.REPEAT, Shader.TileMode.REPEAT);
+            }
+            croutonView.setBackgroundDrawable(drawable);
+        }
+        return croutonView;
+    }
+
+    private RelativeLayout initializeContentView(final Resources resources) {
+        RelativeLayout contentView = new RelativeLayout(this.activity);
+        contentView.setLayoutParams(new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT,
+                RelativeLayout.LayoutParams.WRAP_CONTENT));
+
+        // set padding
+        int padding = this.style.paddingInPixels;
+
+        // if a padding dimension has been set, this will overwrite any padding
+        // in pixels
+        if (this.style.paddingDimensionResId > 0) {
+            padding = resources.getDimensionPixelSize(this.style.paddingDimensionResId);
+        }
+        contentView.setPadding(padding, padding, padding, padding);
+
+        // only setup image if one is requested
+        ImageView image = null;
+        if ((null != this.style.imageDrawable) || (0 != this.style.imageResId)) {
+            image = initializeImageView();
+            contentView.addView(image, image.getLayoutParams());
+        }
+
+        TextView text = initializeTextView(resources);
+
+        RelativeLayout.LayoutParams textParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT,
+                RelativeLayout.LayoutParams.WRAP_CONTENT);
+        if (null != image) {
+            textParams.addRule(RelativeLayout.RIGHT_OF, image.getId());
+        }
+        contentView.addView(text, textParams);
+        return contentView;
+    }
+
+    private TextView initializeTextView(final Resources resources) {
+        TextView text = new TextView(this.activity);
+        text.setId(TEXT_ID);
+        text.setText(this.text);
+        text.setTypeface(Typeface.DEFAULT_BOLD);
+        text.setGravity(this.style.gravity);
+
+        // set the text color if set
+        if (this.style.textColorResourceId != 0) {
+            text.setTextColor(resources.getColor(this.style.textColorResourceId));
+        }
+
+        // Set the text size. If the user has set a text size and text
+        // appearance, the text size in the text appearance
+        // will override this.
+        if (this.style.textSize != 0) {
+            text.setTextSize(TypedValue.COMPLEX_UNIT_SP, this.style.textSize);
+        }
+
+        // Setup the shadow if requested
+        if (this.style.textShadowColorResId != 0) {
+            initializeTextViewShadow(resources, text);
+        }
+
+        // Set the text appearance
+        if (this.style.textAppearanceResId != 0) {
+            text.setTextAppearance(this.activity, this.style.textAppearanceResId);
+        }
+        return text;
+    }
+
+    private void initializeTextViewShadow(final Resources resources, final TextView text) {
+        int textShadowColor = resources.getColor(this.style.textShadowColorResId);
+        float textShadowRadius = this.style.textShadowRadius;
+        float textShadowDx = this.style.textShadowDx;
+        float textShadowDy = this.style.textShadowDy;
+        text.setShadowLayer(textShadowRadius, textShadowDx, textShadowDy, textShadowColor);
+    }
+
+    private ImageView initializeImageView() {
+        ImageView image;
+        image = new ImageView(this.activity);
+        image.setId(IMAGE_ID);
+        image.setAdjustViewBounds(true);
+        image.setScaleType(this.style.imageScaleType);
+
+        // set the image drawable if not null
+        if (null != this.style.imageDrawable) {
+            image.setImageDrawable(this.style.imageDrawable);
+        }
+
+        // set the image resource if not 0. This will overwrite the drawable
+        // if both are set
+        if (this.style.imageResId != 0) {
+            image.setImageResource(this.style.imageResId);
+        }
+
+        RelativeLayout.LayoutParams imageParams = new RelativeLayout.LayoutParams(
+                RelativeLayout.LayoutParams.WRAP_CONTENT,
+                RelativeLayout.LayoutParams.WRAP_CONTENT);
+        imageParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT, RelativeLayout.TRUE);
+        imageParams.addRule(RelativeLayout.CENTER_VERTICAL, RelativeLayout.TRUE);
+
+        image.setLayoutParams(imageParams);
+
+        return image;
+    }
+
+    @Override
+    public String toString() {
+        return "Crouton{" +
+                "text=" + text +
+                ", style=" + style +
+                ", customView=" + customView +
+                ", activity=" + activity +
+                ", viewGroup=" + viewGroup +
+                ", croutonView=" + croutonView +
+                ", inAnimation=" + inAnimation +
+                ", outAnimation=" + outAnimation +
+                ", lifecycleCallback=" + lifecycleCallback +
+                '}';
+    }
+
+
 }

--- a/library/src/de/keyboardsurfer/android/widget/crouton/Manager.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Manager.java
@@ -38,366 +38,366 @@ import java.util.concurrent.LinkedBlockingQueue;
  * Manages the lifecycle of {@link Crouton}s.
  */
 final class Manager extends Handler {
-  private static final class Messages {
-    private Messages() { /* no-op */
+    private static final class Messages {
+        private Messages() { /* no-op */
+        }
+
+        public static final int DISPLAY_CROUTON = 0xc2007;
+        public static final int ADD_CROUTON_TO_VIEW = 0xc20074dd;
+        public static final int REMOVE_CROUTON = 0xc2007de1;
     }
 
-    public static final int DISPLAY_CROUTON = 0xc2007;
-    public static final int ADD_CROUTON_TO_VIEW = 0xc20074dd;
-    public static final int REMOVE_CROUTON = 0xc2007de1;
-  }
+    private static Manager INSTANCE;
 
-  private static Manager INSTANCE;
+    private Queue<Crouton> croutonQueue;
 
-  private Queue<Crouton> croutonQueue;
-
-  private Manager() {
-    croutonQueue = new LinkedBlockingQueue<Crouton>();
-  }
-
-  /**
-   * @return The currently used instance of the {@link Manager}.
-   */
-  static synchronized Manager getInstance() {
-    if (null == INSTANCE) {
-      INSTANCE = new Manager();
+    private Manager() {
+        croutonQueue = new LinkedBlockingQueue<Crouton>();
     }
 
-    return INSTANCE;
-  }
+    /**
+     * @return The currently used instance of the {@link Manager}.
+     */
+    static synchronized Manager getInstance() {
+        if (null == INSTANCE) {
+            INSTANCE = new Manager();
+        }
 
-  /**
-   * Inserts a {@link Crouton} to be displayed.
-   *
-   * @param crouton
-   *   The {@link Crouton} to be displayed.
-   */
-  void add(Crouton crouton) {
-    croutonQueue.add(crouton);
-    displayCrouton();
-  }
-
-  /**
-   * Displays the next {@link Crouton} within the queue.
-   */
-  private void displayCrouton() {
-    if (croutonQueue.isEmpty()) {
-      return;
+        return INSTANCE;
     }
 
-    // First peek whether the Crouton has an activity.
-    final Crouton currentCrouton = croutonQueue.peek();
-
-    // If the activity is null we poll the Crouton off the queue.
-    if (null == currentCrouton.getActivity()) {
-      croutonQueue.poll();
-    }
-
-    if (!currentCrouton.isShowing()) {
-      // Display the Crouton
-      sendMessage(currentCrouton, Messages.ADD_CROUTON_TO_VIEW);
-      if (null != currentCrouton.getLifecycleCallback()) {
-        currentCrouton.getLifecycleCallback().onDisplayed();
-      }
-    } else {
-      sendMessageDelayed(currentCrouton, Messages.DISPLAY_CROUTON, calculateCroutonDuration(currentCrouton));
-    }
-  }
-
-  private long calculateCroutonDuration(Crouton crouton) {
-    long croutonDuration = crouton.getStyle().durationInMilliseconds;
-    croutonDuration += crouton.getInAnimation().getDuration();
-    croutonDuration += crouton.getOutAnimation().getDuration();
-    return croutonDuration;
-  }
-
-  /**
-   * Sends a {@link Crouton} within a {@link Message}.
-   *
-   * @param crouton
-   *   The {@link Crouton} that should be sent.
-   * @param messageId
-   *   The {@link Message} id.
-   */
-  private void sendMessage(Crouton crouton, final int messageId) {
-    final Message message = obtainMessage(messageId);
-    message.obj = crouton;
-    sendMessage(message);
-  }
-
-  /**
-   * Sends a {@link Crouton} within a delayed {@link Message}.
-   *
-   * @param crouton
-   *   The {@link Crouton} that should be sent.
-   * @param messageId
-   *   The {@link Message} id.
-   * @param delay
-   *   The delay in milliseconds.
-   */
-  private void sendMessageDelayed(Crouton crouton, final int messageId, final long delay) {
-    Message message = obtainMessage(messageId);
-    message.obj = crouton;
-    sendMessageDelayed(message, delay);
-  }
-
-  /*
-   * (non-Javadoc)
-   *
-   * @see android.os.Handler#handleMessage(android.os.Message)
-   */
-  @Override
-  public void handleMessage(Message message) {
-    final Crouton crouton = (Crouton) message.obj;
-
-    switch (message.what) {
-      case Messages.DISPLAY_CROUTON: {
+    /**
+     * Inserts a {@link Crouton} to be displayed.
+     *
+     * @param crouton
+     *   The {@link Crouton} to be displayed.
+     */
+    void add(Crouton crouton) {
+        croutonQueue.add(crouton);
         displayCrouton();
-        break;
-      }
+    }
 
-      case Messages.ADD_CROUTON_TO_VIEW: {
-        addCroutonToView(crouton);
-        break;
-      }
-
-      case Messages.REMOVE_CROUTON: {
-        removeCrouton(crouton);
-        if (null != crouton.getLifecycleCallback()) {
-          crouton.getLifecycleCallback().onRemoved();
+    /**
+     * Displays the next {@link Crouton} within the queue.
+     */
+    private void displayCrouton() {
+        if (croutonQueue.isEmpty()) {
+            return;
         }
-        break;
-      }
 
-      default: {
-        super.handleMessage(message);
-        break;
-      }
-    }
-  }
+        // First peek whether the Crouton has an activity.
+        final Crouton currentCrouton = croutonQueue.peek();
 
-  /**
-   * Adds a {@link Crouton} to the {@link ViewParent} of it's {@link Activity}.
-   *
-   * @param crouton
-   *   The {@link Crouton} that should be added.
-   */
-  private void addCroutonToView(Crouton crouton) {
-    // don't add if it is already showing
-    if (crouton.isShowing()) {
-      return;
-    }
+        // If the activity is null we poll the Crouton off the queue.
+        if (null == currentCrouton.getActivity()) {
+            croutonQueue.poll();
+        }
 
-    View croutonView = crouton.getView();
-    if (null == croutonView.getParent()) {
-      ViewGroup.LayoutParams params = croutonView.getLayoutParams();
-      if (null == params) {
-        params = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-      }
-      // display Crouton in ViewGroup is it has been supplied
-      if (null != crouton.getViewGroup()) {
-        // TODO implement add to last position feature (need to align with how this will be requested for activity)
-        if (crouton.getViewGroup() instanceof FrameLayout) {
-          crouton.getViewGroup().addView(croutonView, params);
+        if (!currentCrouton.isShowing()) {
+            // Display the Crouton
+            sendMessage(currentCrouton, Messages.ADD_CROUTON_TO_VIEW);
+            if (null != currentCrouton.getLifecycleCallback()) {
+                currentCrouton.getLifecycleCallback().onDisplayed();
+            }
         } else {
-          crouton.getViewGroup().addView(croutonView, 0, params);
+            sendMessageDelayed(currentCrouton, Messages.DISPLAY_CROUTON, calculateCroutonDuration(currentCrouton));
         }
-      } else {
-        Activity activity = crouton.getActivity();
-        if (null == activity || activity.isFinishing()) {
-          return;
+    }
+
+    private long calculateCroutonDuration(Crouton crouton) {
+        long croutonDuration = crouton.getConfiguration().durationInMilliseconds;
+        croutonDuration += crouton.getInAnimation().getDuration();
+        croutonDuration += crouton.getOutAnimation().getDuration();
+        return croutonDuration;
+    }
+
+    /**
+     * Sends a {@link Crouton} within a {@link Message}.
+     *
+     * @param crouton
+     *   The {@link Crouton} that should be sent.
+     * @param messageId
+     *   The {@link Message} id.
+     */
+    private void sendMessage(Crouton crouton, final int messageId) {
+        final Message message = obtainMessage(messageId);
+        message.obj = crouton;
+        sendMessage(message);
+    }
+
+    /**
+     * Sends a {@link Crouton} within a delayed {@link Message}.
+     *
+     * @param crouton
+     *   The {@link Crouton} that should be sent.
+     * @param messageId
+     *   The {@link Message} id.
+     * @param delay
+     *   The delay in milliseconds.
+     */
+    private void sendMessageDelayed(Crouton crouton, final int messageId, final long delay) {
+        Message message = obtainMessage(messageId);
+        message.obj = crouton;
+        sendMessageDelayed(message, delay);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see android.os.Handler#handleMessage(android.os.Message)
+     */
+    @Override
+    public void handleMessage(Message message) {
+        final Crouton crouton = (Crouton) message.obj;
+
+        switch (message.what) {
+            case Messages.DISPLAY_CROUTON: {
+                displayCrouton();
+                break;
+            }
+
+            case Messages.ADD_CROUTON_TO_VIEW: {
+                addCroutonToView(crouton);
+                break;
+            }
+
+            case Messages.REMOVE_CROUTON: {
+                removeCrouton(crouton);
+                if (null != crouton.getLifecycleCallback()) {
+                    crouton.getLifecycleCallback().onRemoved();
+                }
+                break;
+            }
+
+            default: {
+                super.handleMessage(message);
+                break;
+            }
         }
-        activity.addContentView(croutonView, params);
-      }
     }
-    croutonView.startAnimation(crouton.getInAnimation());
-    announceForAccessibilityCompat(crouton.getActivity(), crouton.getText());
-    if (Style.DURATION_INFINITE != crouton.getStyle().durationInMilliseconds) {
-      sendMessageDelayed(crouton, Messages.REMOVE_CROUTON,
-        crouton.getStyle().durationInMilliseconds + crouton.getInAnimation().getDuration());
-    }
-  }
 
-  /**
-   * Removes the {@link Crouton}'s view after it's display
-   * durationInMilliseconds.
-   *
-   * @param crouton
-   *   The {@link Crouton} added to a {@link ViewGroup} and should be
-   *   removed.
-   */
-  protected void removeCrouton(Crouton crouton) {
-    View croutonView = crouton.getView();
-    ViewGroup croutonParentView = (ViewGroup) croutonView.getParent();
-
-    if (null != croutonParentView) {
-      croutonView.startAnimation(crouton.getOutAnimation());
-
-      // Remove the Crouton from the queue.
-      Crouton removed = croutonQueue.poll();
-
-      // Remove the crouton from the view's parent.
-      croutonParentView.removeView(croutonView);
-      if (null != removed) {
-        removed.detachActivity();
-        removed.detachViewGroup();
-        if (null != removed.getLifecycleCallback()) {
-          removed.getLifecycleCallback().onRemoved();
-        }
-        removed.detachLifecycleCallback();
-      }
-
-      // Send a message to display the next crouton but delay it by the out
-      // animation duration to make sure it finishes
-      sendMessageDelayed(crouton, Messages.DISPLAY_CROUTON, crouton.getOutAnimation().getDuration());
-    }
-  }
-
-  /**
-   * Removes a {@link Crouton} immediately, even when it's currently being
-   * displayed.
-   *
-   * @param crouton
-   *   The {@link Crouton} that should be removed.
-   */
-  void removeCroutonImmediately(Crouton crouton) {
-    // if Crouton has already been displayed then it may not be in the queue (because it was popped).
-    // This ensures the displayed Crouton is removed from its parent immediately, whether another instance
-    // of it exists in the queue or not.
-    // Note: crouton.isShowing() is false here even if it really is showing, as croutonView object in
-    // Crouton seems to be out of sync with reality!
-    if (null != crouton.getActivity() && null != crouton.getView() && null != crouton.getView().getParent()) {
-      ((ViewGroup) crouton.getView().getParent()).removeView(crouton.getView());
-
-      // remove any messages pending for the crouton
-      removeAllMessagesForCrouton(crouton);
-    }
-    // remove any matching croutons from queue
-    if (null != croutonQueue) {
-      final Iterator<Crouton> croutonIterator = croutonQueue.iterator();
-      while (croutonIterator.hasNext()) {
-        final Crouton c = croutonIterator.next();
-        if (c.equals(crouton) && (null != c.getActivity())) {
-          // remove the crouton from the content view
-          if (crouton.isShowing()) {
-            ((ViewGroup) c.getView().getParent()).removeView(c.getView());
-          }
-
-          // remove any messages pending for the crouton
-          removeAllMessagesForCrouton(c);
-
-          // remove the crouton from the queue
-          croutonIterator.remove();
-
-          // we have found our crouton so just break
-          break;
-        }
-      }
-    }
-  }
-
-  /**
-   * Removes all {@link Crouton}s from the queue.
-   */
-  void clearCroutonQueue() {
-    removeAllMessages();
-
-    if (null != croutonQueue) {
-      // remove any views that may already have been added to the activity's
-      // content view
-      for (Crouton crouton : croutonQueue) {
+    /**
+     * Adds a {@link Crouton} to the {@link ViewParent} of it's {@link Activity}.
+     *
+     * @param crouton
+     *   The {@link Crouton} that should be added.
+     */
+    private void addCroutonToView(Crouton crouton) {
+        // don't add if it is already showing
         if (crouton.isShowing()) {
-          ((ViewGroup) crouton.getView().getParent()).removeView(crouton.getView());
+            return;
         }
-      }
-      croutonQueue.clear();
-    }
-  }
 
-  /**
-   * Removes all {@link Crouton}s for the provided activity. This will remove
-   * crouton from {@link Activity}s content view immediately.
-   */
-  void clearCroutonsForActivity(Activity activity) {
-    if (null != croutonQueue) {
-      Iterator<Crouton> croutonIterator = croutonQueue.iterator();
-      while (croutonIterator.hasNext()) {
-        Crouton crouton = croutonIterator.next();
-        if ((null != crouton.getActivity()) && crouton.getActivity().equals(activity)) {
-          // remove the crouton from the content view
-          if (crouton.isShowing()) {
+        View croutonView = crouton.getView();
+        if (null == croutonView.getParent()) {
+            ViewGroup.LayoutParams params = croutonView.getLayoutParams();
+            if (null == params) {
+                params = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+            }
+            // display Crouton in ViewGroup is it has been supplied
+            if (null != crouton.getViewGroup()) {
+                // TODO implement add to last position feature (need to align with how this will be requested for activity)
+                if (crouton.getViewGroup() instanceof FrameLayout) {
+                    crouton.getViewGroup().addView(croutonView, params);
+                } else {
+                    crouton.getViewGroup().addView(croutonView, 0, params);
+                }
+            } else {
+                Activity activity = crouton.getActivity();
+                if (null == activity || activity.isFinishing()) {
+                    return;
+                }
+                activity.addContentView(croutonView, params);
+            }
+        }
+        croutonView.startAnimation(crouton.getInAnimation());
+        announceForAccessibilityCompat(crouton.getActivity(), crouton.getText());
+        if (Configuration.DURATION_INFINITE != crouton.getConfiguration().durationInMilliseconds) {
+            sendMessageDelayed(crouton, Messages.REMOVE_CROUTON,
+                    crouton.getConfiguration().durationInMilliseconds + crouton.getInAnimation().getDuration());
+        }
+    }
+
+    /**
+     * Removes the {@link Crouton}'s view after it's display
+     * durationInMilliseconds.
+     *
+     * @param crouton
+     *   The {@link Crouton} added to a {@link ViewGroup} and should be
+     *   removed.
+     */
+    protected void removeCrouton(Crouton crouton) {
+        View croutonView = crouton.getView();
+        ViewGroup croutonParentView = (ViewGroup) croutonView.getParent();
+
+        if (null != croutonParentView) {
+            croutonView.startAnimation(crouton.getOutAnimation());
+
+            // Remove the Crouton from the queue.
+            Crouton removed = croutonQueue.poll();
+
+            // Remove the crouton from the view's parent.
+            croutonParentView.removeView(croutonView);
+            if (null != removed) {
+                removed.detachActivity();
+                removed.detachViewGroup();
+                if (null != removed.getLifecycleCallback()) {
+                    removed.getLifecycleCallback().onRemoved();
+                }
+                removed.detachLifecycleCallback();
+            }
+
+            // Send a message to display the next crouton but delay it by the out
+            // animation duration to make sure it finishes
+            sendMessageDelayed(crouton, Messages.DISPLAY_CROUTON, crouton.getOutAnimation().getDuration());
+        }
+    }
+
+    /**
+     * Removes a {@link Crouton} immediately, even when it's currently being
+     * displayed.
+     *
+     * @param crouton
+     *   The {@link Crouton} that should be removed.
+     */
+    void removeCroutonImmediately(Crouton crouton) {
+        // if Crouton has already been displayed then it may not be in the queue (because it was popped).
+        // This ensures the displayed Crouton is removed from its parent immediately, whether another instance
+        // of it exists in the queue or not.
+        // Note: crouton.isShowing() is false here even if it really is showing, as croutonView object in
+        // Crouton seems to be out of sync with reality!
+        if (null != crouton.getActivity() && null != crouton.getView() && null != crouton.getView().getParent()) {
             ((ViewGroup) crouton.getView().getParent()).removeView(crouton.getView());
-          }
 
-          removeAllMessagesForCrouton(crouton);
-
-          // remove the crouton from the queue
-          croutonIterator.remove();
+            // remove any messages pending for the crouton
+            removeAllMessagesForCrouton(crouton);
         }
-      }
+        // remove any matching croutons from queue
+        if (null != croutonQueue) {
+            final Iterator<Crouton> croutonIterator = croutonQueue.iterator();
+            while (croutonIterator.hasNext()) {
+                final Crouton c = croutonIterator.next();
+                if (c.equals(crouton) && (null != c.getActivity())) {
+                    // remove the crouton from the content view
+                    if (crouton.isShowing()) {
+                        ((ViewGroup) c.getView().getParent()).removeView(c.getView());
+                    }
+
+                    // remove any messages pending for the crouton
+                    removeAllMessagesForCrouton(c);
+
+                    // remove the crouton from the queue
+                    croutonIterator.remove();
+
+                    // we have found our crouton so just break
+                    break;
+                }
+            }
+        }
     }
-  }
 
-  private void removeAllMessages() {
-    removeMessages(Messages.ADD_CROUTON_TO_VIEW);
-    removeMessages(Messages.DISPLAY_CROUTON);
-    removeMessages(Messages.REMOVE_CROUTON);
-  }
+    /**
+     * Removes all {@link Crouton}s from the queue.
+     */
+    void clearCroutonQueue() {
+        removeAllMessages();
 
-  private void removeAllMessagesForCrouton(Crouton crouton) {
-    removeMessages(Messages.ADD_CROUTON_TO_VIEW, crouton);
-    removeMessages(Messages.DISPLAY_CROUTON, crouton);
-    removeMessages(Messages.REMOVE_CROUTON, crouton);
-
-  }
-
-  /**
-   * Generates and dispatches an SDK-specific spoken announcement.
-   * <p>
-   * For backwards compatibility, we're constructing an event from scratch
-   * using the appropriate event type. If your application only targets SDK
-   * 16+, you can just call View.announceForAccessibility(CharSequence).
-   * </p>
-   * <p/>
-   * note: AccessibilityManager is only available from API lvl 4.
-   * <p/>
-   * Adapted from https://http://eyes-free.googlecode.com/files/accessibility_codelab_demos_v2_src.zip
-   * via https://github.com/coreform/android-formidable-validation
-   *
-   * @param context
-   *   Used to get {@link AccessibilityManager}
-   * @param text
-   *   The text to announce.
-   */
-  public static void announceForAccessibilityCompat(Context context, CharSequence text) {
-    if (Build.VERSION.SDK_INT >= 4) {
-      AccessibilityManager accessibilityManager = (AccessibilityManager) context.getSystemService(
-        Context.ACCESSIBILITY_SERVICE);
-      if (!accessibilityManager.isEnabled()) {
-        return;
-      }
-
-      // Prior to SDK 16, announcements could only be made through FOCUSED
-      // events. Jelly Bean (SDK 16) added support for speaking text verbatim
-      // using the ANNOUNCEMENT event type.
-      final int eventType;
-      if (Build.VERSION.SDK_INT < 16) {
-        eventType = AccessibilityEvent.TYPE_VIEW_FOCUSED;
-      } else {
-        eventType = AccessibilityEventCompat.TYPE_ANNOUNCEMENT;
-      }
-
-      // Construct an accessibility event with the minimum recommended
-      // attributes. An event without a class name or package may be dropped.
-      final AccessibilityEvent event = AccessibilityEvent.obtain(eventType);
-      event.getText().add(text);
-      event.setClassName(Manager.class.getName());
-      event.setPackageName(context.getPackageName());
-
-      // Sends the event directly through the accessibility manager. If your
-      // application only targets SDK 14+, you should just call
-      // getParent().requestSendAccessibilityEvent(this, event);
-      accessibilityManager.sendAccessibilityEvent(event);
+        if (null != croutonQueue) {
+            // remove any views that may already have been added to the activity's
+            // content view
+            for (Crouton crouton : croutonQueue) {
+                if (crouton.isShowing()) {
+                    ((ViewGroup) crouton.getView().getParent()).removeView(crouton.getView());
+                }
+            }
+            croutonQueue.clear();
+        }
     }
-  }
+
+    /**
+     * Removes all {@link Crouton}s for the provided activity. This will remove
+     * crouton from {@link Activity}s content view immediately.
+     */
+    void clearCroutonsForActivity(Activity activity) {
+        if (null != croutonQueue) {
+            Iterator<Crouton> croutonIterator = croutonQueue.iterator();
+            while (croutonIterator.hasNext()) {
+                Crouton crouton = croutonIterator.next();
+                if ((null != crouton.getActivity()) && crouton.getActivity().equals(activity)) {
+                    // remove the crouton from the content view
+                    if (crouton.isShowing()) {
+                        ((ViewGroup) crouton.getView().getParent()).removeView(crouton.getView());
+                    }
+
+                    removeAllMessagesForCrouton(crouton);
+
+                    // remove the crouton from the queue
+                    croutonIterator.remove();
+                }
+            }
+        }
+    }
+
+    private void removeAllMessages() {
+        removeMessages(Messages.ADD_CROUTON_TO_VIEW);
+        removeMessages(Messages.DISPLAY_CROUTON);
+        removeMessages(Messages.REMOVE_CROUTON);
+    }
+
+    private void removeAllMessagesForCrouton(Crouton crouton) {
+        removeMessages(Messages.ADD_CROUTON_TO_VIEW, crouton);
+        removeMessages(Messages.DISPLAY_CROUTON, crouton);
+        removeMessages(Messages.REMOVE_CROUTON, crouton);
+
+    }
+
+    /**
+     * Generates and dispatches an SDK-specific spoken announcement.
+     * <p>
+     * For backwards compatibility, we're constructing an event from scratch
+     * using the appropriate event type. If your application only targets SDK
+     * 16+, you can just call View.announceForAccessibility(CharSequence).
+     * </p>
+     * <p/>
+     * note: AccessibilityManager is only available from API lvl 4.
+     * <p/>
+     * Adapted from https://http://eyes-free.googlecode.com/files/accessibility_codelab_demos_v2_src.zip
+     * via https://github.com/coreform/android-formidable-validation
+     *
+     * @param context
+     *   Used to get {@link AccessibilityManager}
+     * @param text
+     *   The text to announce.
+     */
+    public static void announceForAccessibilityCompat(Context context, CharSequence text) {
+        if (Build.VERSION.SDK_INT >= 4) {
+            AccessibilityManager accessibilityManager = (AccessibilityManager) context.getSystemService(
+                    Context.ACCESSIBILITY_SERVICE);
+            if (!accessibilityManager.isEnabled()) {
+                return;
+            }
+
+            // Prior to SDK 16, announcements could only be made through FOCUSED
+            // events. Jelly Bean (SDK 16) added support for speaking text verbatim
+            // using the ANNOUNCEMENT event type.
+            final int eventType;
+            if (Build.VERSION.SDK_INT < 16) {
+                eventType = AccessibilityEvent.TYPE_VIEW_FOCUSED;
+            } else {
+                eventType = AccessibilityEventCompat.TYPE_ANNOUNCEMENT;
+            }
+
+            // Construct an accessibility event with the minimum recommended
+            // attributes. An event without a class name or package may be dropped.
+            final AccessibilityEvent event = AccessibilityEvent.obtain(eventType);
+            event.getText().add(text);
+            event.setClassName(Manager.class.getName());
+            event.setPackageName(context.getPackageName());
+
+            // Sends the event directly through the accessibility manager. If your
+            // application only targets SDK 14+, you should just call
+            // getParent().requestSendAccessibilityEvent(this, event);
+            accessibilityManager.sendAccessibilityEvent(event);
+        }
+    }
 }

--- a/library/src/de/keyboardsurfer/android/widget/crouton/Style.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Style.java
@@ -29,511 +29,492 @@ import android.widget.ImageView;
 
 public class Style {
 
-  /**
-   * Display a {@link Crouton} for an infinite amount of time or 
-   * until {@link de.keyboardsurfer.android.widget.crouton.Crouton#cancel()} has been called.
-   */
-  public static final int DURATION_INFINITE = -1;
 
-  /**
-   * Default style for alerting the user.
-   */
-  public static final Style ALERT;
-  /**
-   * Default style for confirming an action.
-   */
-  public static final Style CONFIRM;
-  /**
-   * Default style for general information.
-   */
-  public static final Style INFO;
+    /**
+     * Default style for alerting the user.
+     */
+    public static final Style ALERT;
+    /**
+     * Default style for confirming an action.
+     */
+    public static final Style CONFIRM;
+    /**
+     * Default style for general information.
+     */
+    public static final Style INFO;
 
-  public static final int holoRedLight = 0xffff4444;
-  public static final int holoGreenLight = 0xff99cc00;
-  public static final int holoBlueLight = 0xff33b5e5;
+    public static final int holoRedLight = 0xffff4444;
+    public static final int holoGreenLight = 0xff99cc00;
+    public static final int holoBlueLight = 0xff33b5e5;
 
-  static {
-    ALERT = new Builder().setDuration(5000).setBackgroundColorValue(holoRedLight).setHeight(LayoutParams.WRAP_CONTENT)
-      .build();
-    CONFIRM = new Builder().setDuration(3000).setBackgroundColorValue(holoGreenLight).setHeight(
-      LayoutParams.WRAP_CONTENT).build();
-    INFO = new Builder().setDuration(3000).setBackgroundColorValue(holoBlueLight).setHeight(LayoutParams.WRAP_CONTENT)
-      .build();
-  }
-
-  /**
-   * The durationInMilliseconds the {@link Crouton} will be displayed in
-   * milliseconds.
-   */
-  final int durationInMilliseconds;
-
-  /**
-   * The resource id of the backgroundResourceId.
-   * <p/>
-   * 0 for no backgroundResourceId.
-   */
-  final int backgroundColorResourceId;
-
-  /**
-   * The resource id of the backgroundDrawableResourceId.
-   * <p/>
-   * 0 for no backgroundDrawableResourceId.
-   */
-  final int backgroundDrawableResourceId;
-
-  /**
-   * The backgroundColorResourceValue's e.g. 0xffff4444;
-   * <p/>
-   * -1 for no value.
-   */
-  final int backgroundColorValue;
-
-  /**
-   * Whether we should isTileEnabled the backgroundResourceId or not.
-   */
-  final boolean isTileEnabled;
-
-  /**
-   * The text colorResourceId's resource id.
-   * <p/>
-   * 0 sets the text colorResourceId to the system theme default.
-   */
-  final int textColorResourceId;
-
-  /**
-   * The height of the {@link Crouton} in pixels.
-   */
-  final int heightInPixels;
-
-  /**
-   * Resource ID for the height of the {@link Crouton}.
-   */
-  final int heightDimensionResId;
-  
-  /**
-   * The width of the {@link Crouton} in pixels.
-   */
-  final int widthInPixels;
-  
-  /**
-   * Resource ID for the width of the {@link Crouton}.
-   */
-  final int widthDimensionResId;
-
-  /**
-   * The text's gravity as provided by {@link Gravity}.
-   */
-  final int gravity;
-
-  /**
-   * An additional image to display in the {@link Crouton}.
-   */
-  final Drawable imageDrawable;
-
-  /**
-   * An additional image to display in the {@link Crouton}.
-   */
-  final int imageResId;
-
-  /**
-   * The {@link ImageView.ScaleType} for the image to display in the
-   * {@link Crouton}.
-   */
-  final ImageView.ScaleType imageScaleType;
-
-  /**
-   * The text size in sp
-   * <p/>
-   * 0 sets the text size to the system theme default
-   */
-  final int textSize;
-
-  /**
-   * The text shadow color's resource id
-   */
-  final int textShadowColorResId;
-
-  /**
-   * The text shadow radius
-   */
-  final float textShadowRadius;
-
-  /**
-   * The text shadow vertical offset
-   */
-  final float textShadowDy;
-
-  /**
-   * The text shadow horizontal offset
-   */
-  final float textShadowDx;
-
-  /**
-   * The text appearance resource id for the text.
-   */
-  final int textAppearanceResId;
-
-  /**
-   * The resource id for the in animation
-   */
-  final int inAnimationResId;
-
-  /**
-   * The resource id for the out animation
-   */
-  final int outAnimationResId;
-
-  /**
-   * The padding for the crouton view content in pixels
-   */
-  final int paddingInPixels;
-
-  /**
-   * The resource id for the padding for the view content
-   */
-  final int paddingDimensionResId;
-
-  private Style(final Builder builder) {
-    this.durationInMilliseconds = builder.durationInMilliseconds;
-    this.backgroundColorResourceId = builder.backgroundColorResourceId;
-    this.backgroundDrawableResourceId = builder.backgroundDrawableResourceId;
-    this.isTileEnabled = builder.isTileEnabled;
-    this.textColorResourceId = builder.textColorResourceId;
-    this.heightInPixels = builder.heightInPixels;
-    this.heightDimensionResId = builder.heightDimensionResId;
-    this.widthInPixels = builder.widthInPixels;
-    this.widthDimensionResId = builder.widthDimensionResId;
-    this.gravity = builder.gravity;
-    this.imageDrawable = builder.imageDrawable;
-    this.textSize = builder.textSize;
-    this.textShadowColorResId = builder.textShadowColorResId;
-    this.textShadowRadius = builder.textShadowRadius;
-    this.textShadowDx = builder.textShadowDx;
-    this.textShadowDy = builder.textShadowDy;
-    this.textAppearanceResId = builder.textAppearanceResId;
-    this.inAnimationResId = builder.inAnimationResId;
-    this.outAnimationResId = builder.outAnimationResId;
-    this.imageResId = builder.imageResId;
-    this.imageScaleType = builder.imageScaleType;
-    this.paddingInPixels = builder.paddingInPixels;
-    this.paddingDimensionResId = builder.paddingDimensionResId;
-    this.backgroundColorValue = builder.backgroundColorValue;
-  }
-
-  /**
-   * Builder for the {@link Style} object.
-   */
-  public static class Builder {
-    private int durationInMilliseconds;
-    private int backgroundColorValue;
-    private int backgroundColorResourceId;
-    private int backgroundDrawableResourceId;
-    private boolean isTileEnabled;
-    private int textColorResourceId;
-    private int heightInPixels;
-    private int heightDimensionResId;
-    private int widthInPixels;
-    private int widthDimensionResId;
-    private int gravity;
-    private Drawable imageDrawable;
-    private int textSize;
-    private int textShadowColorResId;
-    private float textShadowRadius;
-    private float textShadowDx;
-    private float textShadowDy;
-    private int textAppearanceResId;
-    private int inAnimationResId;
-    private int outAnimationResId;
-    private int imageResId;
-    private ImageView.ScaleType imageScaleType;
-    private int paddingInPixels;
-    private int paddingDimensionResId;
-
-    public Builder() {
-      durationInMilliseconds = 3000;
-      paddingInPixels = 10;
-      backgroundColorResourceId = android.R.color.holo_blue_light;
-      backgroundDrawableResourceId = 0;
-      backgroundColorValue = -1;
-      isTileEnabled = false;
-      textColorResourceId = android.R.color.white;
-      heightInPixels = LayoutParams.WRAP_CONTENT;
-      widthInPixels = LayoutParams.MATCH_PARENT;
-      gravity = Gravity.CENTER;
-      imageDrawable = null;
-      inAnimationResId = 0;
-      outAnimationResId = 0;
-      imageResId = 0;
-      imageScaleType = ImageView.ScaleType.FIT_XY;
+    static {
+        ALERT = new Builder()
+                .setBackgroundColorValue(holoRedLight)
+                .setHeight(LayoutParams.WRAP_CONTENT)
+                .build();
+        CONFIRM = new Builder()
+                .setBackgroundColorValue(holoGreenLight)
+                .setHeight(LayoutParams.WRAP_CONTENT)
+                .build();
+        INFO = new Builder()
+                .setBackgroundColorValue(holoBlueLight)
+                .setHeight(LayoutParams.WRAP_CONTENT)
+                .build();
     }
 
     /**
-     * Set the durationInMilliseconds option of the {@link Crouton}.
-     *
-     * @param duration
-     *          The durationInMilliseconds the crouton will be displayed
-     *          {@link Crouton} in milliseconds.
-     * @return the {@link Builder}.
+     * The resource id of the backgroundResourceId.
+     * <p/>
+     * 0 for no backgroundResourceId.
      */
-    public Builder setDuration(int duration) {
-      this.durationInMilliseconds = duration;
-
-      return this;
-    }
+    final int backgroundColorResourceId;
 
     /**
-     * Set the backgroundColorResourceId option of the {@link Crouton}.
-     *
-     * @param backgroundColorResourceId
-     *          The backgroundColorResourceId's resource id.
-     * @return the {@link Builder}.
+     * The resource id of the backgroundDrawableResourceId.
+     * <p/>
+     * 0 for no backgroundDrawableResourceId.
      */
-    public Builder setBackgroundColor(int backgroundColorResourceId) {
-      this.backgroundColorResourceId = backgroundColorResourceId;
-
-      return this;
-    }
+    final int backgroundDrawableResourceId;
 
     /**
-     * Set the backgroundColorResourceValue option of the {@link Crouton}.
-     *
-     * @param backgroundColorValue
-     *          The backgroundColorResourceValue's e.g. 0xffff4444;
-     * @return the {@link Builder}.
+     * The backgroundColorResourceValue's e.g. 0xffff4444;
+     * <p/>
+     * -1 for no value.
      */
-    public Builder setBackgroundColorValue(int backgroundColorValue) {
-      this.backgroundColorValue = backgroundColorValue;
-      return this;
-    }
+    final int backgroundColorValue;
 
     /**
-     * Set the backgroundDrawableResourceId option for the {@link Crouton}.
-     *
-     * @param backgroundDrawableResourceId
-     *          Resource ID of a backgroundDrawableResourceId image drawable.
-     * @return the {@link Builder}.
+     * Whether we should isTileEnabled the backgroundResourceId or not.
      */
-    public Builder setBackgroundDrawable(int backgroundDrawableResourceId) {
-      this.backgroundDrawableResourceId = backgroundDrawableResourceId;
-
-      return this;
-    }
+    final boolean isTileEnabled;
 
     /**
-     * Set the heightInPixels option for the {@link Crouton}.
-     *
-     * @param height
-     *          The height of the {@link Crouton} in pixel. Can also be
-     *          {@link LayoutParams#MATCH_PARENT} or
-     *          {@link LayoutParams#WRAP_CONTENT}.
-     * @return the {@link Builder}.
+     * The text colorResourceId's resource id.
+     * <p/>
+     * 0 sets the text colorResourceId to the system theme default.
      */
-    public Builder setHeight(int height) {
-      this.heightInPixels = height;
-
-      return this;
-    }
+    final int textColorResourceId;
 
     /**
-     * Set the resource id for the height option for the {@link Crouton}.
-     *
-     * @param heightDimensionResId
-     *          Resource ID of a dimension for the height of the {@link Crouton}.
-     * @return the {@link Builder}.
+     * The height of the {@link Crouton} in pixels.
      */
-    public Builder setHeightDimensionResId(int heightDimensionResId) {
-      this.heightDimensionResId = heightDimensionResId;
-
-      return this;
-    }
+    final int heightInPixels;
 
     /**
-     * Set the widthInPixels option for the {@link Crouton}.
-     *
-     * @param width
-     *          The width of the {@link Crouton} in pixel. Can also be
-     *          {@link LayoutParams#MATCH_PARENT} or
-     *          {@link LayoutParams#WRAP_CONTENT}.
-     * @return the {@link Builder}.
+     * Resource ID for the height of the {@link Crouton}.
      */
-    public Builder setWidth(int width) {
-      this.widthInPixels = width;
-
-      return this;
-    }
+    final int heightDimensionResId;
 
     /**
-     * Set the resource id for the width option for the {@link Crouton}.
-     *
-     * @param widthDimensionResId
-     *          Resource ID of a dimension for the width of the {@link Crouton}.
-     * @return the {@link Builder}.
+     * The width of the {@link Crouton} in pixels.
      */
-    public Builder setWidthDimensionResId(int widthDimensionResId) {
-      this.widthDimensionResId = widthDimensionResId;
-
-      return this;
-    }
+    final int widthInPixels;
 
     /**
-     * Set the isTileEnabled option for the {@link Crouton}.
-     *
-     * @param isTileEnabled
-     *          <code>true</code> if you want the backgroundResourceId to be
-     *          tiled, else <code>false</code>.
-     * @return the {@link Builder}.
+     * Resource ID for the width of the {@link Crouton}.
      */
-    public Builder setTileEnabled(boolean isTileEnabled) {
-      this.isTileEnabled = isTileEnabled;
-
-      return this;
-    }
+    final int widthDimensionResId;
 
     /**
-     * Set the textColorResourceId option for the {@link Crouton}.
-     *
-     * @param textColor
-     *          The resource id of the text colorResourceId.
-     * @return the {@link Builder}.
+     * The text's gravity as provided by {@link Gravity}.
      */
-    public Builder setTextColor(int textColor) {
-      this.textColorResourceId = textColor;
-
-      return this;
-    }
+    final int gravity;
 
     /**
-     * Set the gravity option for the {@link Crouton}.
-     *
-     * @param gravity
-     *          The text's gravity as provided by {@link Gravity}.
-     * @return the {@link Builder}.
+     * An additional image to display in the {@link Crouton}.
      */
-    public Builder setGravity(int gravity) {
-      this.gravity = gravity;
-
-      return this;
-    }
+    final Drawable imageDrawable;
 
     /**
-     * Set the image option for the {@link Crouton}.
-     *
-     * @param imageDrawable
-     *          An additional image to display in the {@link Crouton}.
-     * @return the {@link Builder}.
+     * An additional image to display in the {@link Crouton}.
      */
-    public Builder setImageDrawable(Drawable imageDrawable) {
-      this.imageDrawable = imageDrawable;
-
-      return this;
-    }
+    final int imageResId;
 
     /**
-     * Set the image resource option for the {@link Crouton}.
-     *
-     * @param imageResId
-     *          An additional image to display in the {@link Crouton}.
-     * @return the {@link Builder}.
+     * The {@link ImageView.ScaleType} for the image to display in the
+     * {@link Crouton}.
      */
-    public Builder setImageResource(int imageResId) {
-      this.imageResId = imageResId;
-
-      return this;
-    }
+    final ImageView.ScaleType imageScaleType;
 
     /**
      * The text size in sp
+     * <p/>
+     * 0 sets the text size to the system theme default
      */
-    public Builder setTextSize(int textSize) {
-      this.textSize = textSize;
-      return this;
-    }
+    final int textSize;
 
     /**
      * The text shadow color's resource id
      */
-    public Builder setTextShadowColor(int textShadowColorResId) {
-      this.textShadowColorResId = textShadowColorResId;
-      return this;
-    }
+    final int textShadowColorResId;
 
     /**
      * The text shadow radius
      */
-    public Builder setTextShadowRadius(float textShadowRadius) {
-      this.textShadowRadius = textShadowRadius;
-      return this;
-    }
-
-    /**
-     * The text shadow horizontal offset
-     */
-    public Builder setTextShadowDx(float textShadowDx) {
-      this.textShadowDx = textShadowDx;
-      return this;
-    }
+    final float textShadowRadius;
 
     /**
      * The text shadow vertical offset
      */
-    public Builder setTextShadowDy(float textShadowDy) {
-      this.textShadowDy = textShadowDy;
-      return this;
-    }
+    final float textShadowDy;
+
+    /**
+     * The text shadow horizontal offset
+     */
+    final float textShadowDx;
 
     /**
      * The text appearance resource id for the text.
      */
-    public Builder setTextAppearance(int textAppearanceResId) {
-      this.textAppearanceResId = textAppearanceResId;
-      return this;
-    }
+    final int textAppearanceResId;
 
     /**
      * The resource id for the in animation
      */
-    public Builder setInAnimation(int inAnimationResId) {
-      this.inAnimationResId = inAnimationResId;
-      return this;
-    }
+    final int inAnimationResId;
 
     /**
      * The resource id for the out animation
      */
-    public Builder setOutAnimation(int outAnimationResId) {
-      this.outAnimationResId = outAnimationResId;
-      return this;
+    final int outAnimationResId;
+
+    /**
+     * The padding for the crouton view content in pixels
+     */
+    final int paddingInPixels;
+
+    /**
+     * The resource id for the padding for the view content
+     */
+    final int paddingDimensionResId;
+
+    private Style(final Builder builder) {
+
+        this.backgroundColorResourceId = builder.backgroundColorResourceId;
+        this.backgroundDrawableResourceId = builder.backgroundDrawableResourceId;
+        this.isTileEnabled = builder.isTileEnabled;
+        this.textColorResourceId = builder.textColorResourceId;
+        this.heightInPixels = builder.heightInPixels;
+        this.heightDimensionResId = builder.heightDimensionResId;
+        this.widthInPixels = builder.widthInPixels;
+        this.widthDimensionResId = builder.widthDimensionResId;
+        this.gravity = builder.gravity;
+        this.imageDrawable = builder.imageDrawable;
+        this.textSize = builder.textSize;
+        this.textShadowColorResId = builder.textShadowColorResId;
+        this.textShadowRadius = builder.textShadowRadius;
+        this.textShadowDx = builder.textShadowDx;
+        this.textShadowDy = builder.textShadowDy;
+        this.textAppearanceResId = builder.textAppearanceResId;
+        this.inAnimationResId = builder.inAnimationResId;
+        this.outAnimationResId = builder.outAnimationResId;
+        this.imageResId = builder.imageResId;
+        this.imageScaleType = builder.imageScaleType;
+        this.paddingInPixels = builder.paddingInPixels;
+        this.paddingDimensionResId = builder.paddingDimensionResId;
+        this.backgroundColorValue = builder.backgroundColorValue;
     }
 
     /**
-     * The {@link android.widget.ImageView.ScaleType} for the image
+     * Builder for the {@link Style} object.
      */
-    public Builder setImageScaleType(ImageView.ScaleType imageScaleType) {
-      this.imageScaleType = imageScaleType;
-      return this;
-    }
+    public static class Builder {
+        private int durationInMilliseconds;
+        private int backgroundColorValue;
+        private int backgroundColorResourceId;
+        private int backgroundDrawableResourceId;
+        private boolean isTileEnabled;
+        private int textColorResourceId;
+        private int heightInPixels;
+        private int heightDimensionResId;
+        private int widthInPixels;
+        private int widthDimensionResId;
+        private int gravity;
+        private Drawable imageDrawable;
+        private int textSize;
+        private int textShadowColorResId;
+        private float textShadowRadius;
+        private float textShadowDx;
+        private float textShadowDy;
+        private int textAppearanceResId;
+        private int inAnimationResId;
+        private int outAnimationResId;
+        private int imageResId;
+        private ImageView.ScaleType imageScaleType;
+        private int paddingInPixels;
+        private int paddingDimensionResId;
 
-    /**
-     * The padding for the crouton view's content in pixels
-     */
-    public Builder setPaddingInPixels(int padding) {
-      this.paddingInPixels = padding;
-      return this;
-    }
+        public Builder() {
+            paddingInPixels = 10;
+            backgroundColorResourceId = android.R.color.holo_blue_light;
+            backgroundDrawableResourceId = 0;
+            backgroundColorValue = -1;
+            isTileEnabled = false;
+            textColorResourceId = android.R.color.white;
+            heightInPixels = LayoutParams.WRAP_CONTENT;
+            widthInPixels = LayoutParams.MATCH_PARENT;
+            gravity = Gravity.CENTER;
+            imageDrawable = null;
+            inAnimationResId = 0;
+            outAnimationResId = 0;
+            imageResId = 0;
+            imageScaleType = ImageView.ScaleType.FIT_XY;
+        }
 
-    /**
-     * The resource id for the padding for the crouton view's content
-     */
-    public Builder setPaddingDimensionResId(int paddingResId) {
-      this.paddingDimensionResId = paddingResId;
-      return this;
-    }
 
-    /**
-     * @return a configured {@link Style} object.
-     */
-    public Style build() {
-      return new Style(this);
+        /**
+         * Set the backgroundColorResourceId option of the {@link Crouton}.
+         *
+         * @param backgroundColorResourceId
+         *          The backgroundColorResourceId's resource id.
+         * @return the {@link Builder}.
+         */
+        public Builder setBackgroundColor(int backgroundColorResourceId) {
+            this.backgroundColorResourceId = backgroundColorResourceId;
+
+            return this;
+        }
+
+        /**
+         * Set the backgroundColorResourceValue option of the {@link Crouton}.
+         *
+         * @param backgroundColorValue
+         *          The backgroundColorResourceValue's e.g. 0xffff4444;
+         * @return the {@link Builder}.
+         */
+        public Builder setBackgroundColorValue(int backgroundColorValue) {
+            this.backgroundColorValue = backgroundColorValue;
+            return this;
+        }
+
+        /**
+         * Set the backgroundDrawableResourceId option for the {@link Crouton}.
+         *
+         * @param backgroundDrawableResourceId
+         *          Resource ID of a backgroundDrawableResourceId image drawable.
+         * @return the {@link Builder}.
+         */
+        public Builder setBackgroundDrawable(int backgroundDrawableResourceId) {
+            this.backgroundDrawableResourceId = backgroundDrawableResourceId;
+
+            return this;
+        }
+
+        /**
+         * Set the heightInPixels option for the {@link Crouton}.
+         *
+         * @param height
+         *          The height of the {@link Crouton} in pixel. Can also be
+         *          {@link LayoutParams#MATCH_PARENT} or
+         *          {@link LayoutParams#WRAP_CONTENT}.
+         * @return the {@link Builder}.
+         */
+        public Builder setHeight(int height) {
+            this.heightInPixels = height;
+
+            return this;
+        }
+
+        /**
+         * Set the resource id for the height option for the {@link Crouton}.
+         *
+         * @param heightDimensionResId
+         *          Resource ID of a dimension for the height of the {@link Crouton}.
+         * @return the {@link Builder}.
+         */
+        public Builder setHeightDimensionResId(int heightDimensionResId) {
+            this.heightDimensionResId = heightDimensionResId;
+
+            return this;
+        }
+
+        /**
+         * Set the widthInPixels option for the {@link Crouton}.
+         *
+         * @param width
+         *          The width of the {@link Crouton} in pixel. Can also be
+         *          {@link LayoutParams#MATCH_PARENT} or
+         *          {@link LayoutParams#WRAP_CONTENT}.
+         * @return the {@link Builder}.
+         */
+        public Builder setWidth(int width) {
+            this.widthInPixels = width;
+
+            return this;
+        }
+
+        /**
+         * Set the resource id for the width option for the {@link Crouton}.
+         *
+         * @param widthDimensionResId
+         *          Resource ID of a dimension for the width of the {@link Crouton}.
+         * @return the {@link Builder}.
+         */
+        public Builder setWidthDimensionResId(int widthDimensionResId) {
+            this.widthDimensionResId = widthDimensionResId;
+
+            return this;
+        }
+
+        /**
+         * Set the isTileEnabled option for the {@link Crouton}.
+         *
+         * @param isTileEnabled
+         *          <code>true</code> if you want the backgroundResourceId to be
+         *          tiled, else <code>false</code>.
+         * @return the {@link Builder}.
+         */
+        public Builder setTileEnabled(boolean isTileEnabled) {
+            this.isTileEnabled = isTileEnabled;
+
+            return this;
+        }
+
+        /**
+         * Set the textColorResourceId option for the {@link Crouton}.
+         *
+         * @param textColor
+         *          The resource id of the text colorResourceId.
+         * @return the {@link Builder}.
+         */
+        public Builder setTextColor(int textColor) {
+            this.textColorResourceId = textColor;
+
+            return this;
+        }
+
+        /**
+         * Set the gravity option for the {@link Crouton}.
+         *
+         * @param gravity
+         *          The text's gravity as provided by {@link Gravity}.
+         * @return the {@link Builder}.
+         */
+        public Builder setGravity(int gravity) {
+            this.gravity = gravity;
+
+            return this;
+        }
+
+        /**
+         * Set the image option for the {@link Crouton}.
+         *
+         * @param imageDrawable
+         *          An additional image to display in the {@link Crouton}.
+         * @return the {@link Builder}.
+         */
+        public Builder setImageDrawable(Drawable imageDrawable) {
+            this.imageDrawable = imageDrawable;
+
+            return this;
+        }
+
+        /**
+         * Set the image resource option for the {@link Crouton}.
+         *
+         * @param imageResId
+         *          An additional image to display in the {@link Crouton}.
+         * @return the {@link Builder}.
+         */
+        public Builder setImageResource(int imageResId) {
+            this.imageResId = imageResId;
+
+            return this;
+        }
+
+        /**
+         * The text size in sp
+         */
+        public Builder setTextSize(int textSize) {
+            this.textSize = textSize;
+            return this;
+        }
+
+        /**
+         * The text shadow color's resource id
+         */
+        public Builder setTextShadowColor(int textShadowColorResId) {
+            this.textShadowColorResId = textShadowColorResId;
+            return this;
+        }
+
+        /**
+         * The text shadow radius
+         */
+        public Builder setTextShadowRadius(float textShadowRadius) {
+            this.textShadowRadius = textShadowRadius;
+            return this;
+        }
+
+        /**
+         * The text shadow horizontal offset
+         */
+        public Builder setTextShadowDx(float textShadowDx) {
+            this.textShadowDx = textShadowDx;
+            return this;
+        }
+
+        /**
+         * The text shadow vertical offset
+         */
+        public Builder setTextShadowDy(float textShadowDy) {
+            this.textShadowDy = textShadowDy;
+            return this;
+        }
+
+        /**
+         * The text appearance resource id for the text.
+         */
+        public Builder setTextAppearance(int textAppearanceResId) {
+            this.textAppearanceResId = textAppearanceResId;
+            return this;
+        }
+
+        /**
+         * The resource id for the in animation
+         */
+        public Builder setInAnimation(int inAnimationResId) {
+            this.inAnimationResId = inAnimationResId;
+            return this;
+        }
+
+        /**
+         * The resource id for the out animation
+         */
+        public Builder setOutAnimation(int outAnimationResId) {
+            this.outAnimationResId = outAnimationResId;
+            return this;
+        }
+
+        /**
+         * The {@link android.widget.ImageView.ScaleType} for the image
+         */
+        public Builder setImageScaleType(ImageView.ScaleType imageScaleType) {
+            this.imageScaleType = imageScaleType;
+            return this;
+        }
+
+        /**
+         * The padding for the crouton view's content in pixels
+         */
+        public Builder setPaddingInPixels(int padding) {
+            this.paddingInPixels = padding;
+            return this;
+        }
+
+        /**
+         * The resource id for the padding for the crouton view's content
+         */
+        public Builder setPaddingDimensionResId(int paddingResId) {
+            this.paddingDimensionResId = paddingResId;
+            return this;
+        }
+
+        /**
+         * @return a configured {@link Style} object.
+         */
+        public Style build() {
+            return new Style(this);
+        }
     }
-  }
 }

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -17,107 +17,112 @@
 	-->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <name>Crouton Demo</name>
-  <artifactId>de.keyboardsurfer.app.demo.crouton</artifactId>
-  <version>1.7</version>
-  <groupId>de.keyboardsurfer.app.demo.crouton</groupId>
-  <packaging>apk</packaging>
+    <name>Crouton Demo</name>
+    <groupId>de.keyboardsurfer.app.demo.crouton</groupId>
+    <artifactId>crouton-sample</artifactId>
+    <version>${project.parent.version}</version>
+    <packaging>apk</packaging>
 
-  <developers>
-    <developer>
-      <id>keyboardsurfer</id>
-      <name>Benjamin Weiss</name>
-    </developer>
-  </developers>
+    <developers>
+        <developer>
+            <id>keyboardsurfer</id>
+            <name>Benjamin Weiss</name>
+        </developer>
+    </developers>
 
-  <licenses>
-    <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-  <scm>
-    <url>git@github.com:keyboardsurfer/Crouton.git</url>
-    <developerConnection>scm:git:git@github.com:keyboardsurfer/Crouton.git</developerConnection>
-    <connection>scm:git:git@github.com:keyboardsurfer/Crouton.git</connection>
-  </scm>
+    <scm>
+        <url>git@github.com:keyboardsurfer/Crouton.git</url>
+        <developerConnection>scm:git:git@github.com:keyboardsurfer/Crouton.git</developerConnection>
+        <connection>scm:git:git@github.com:keyboardsurfer/Crouton.git</connection>
+    </scm>
 
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <crouton.version>1.7</crouton.version>
-    <android.version>4.1.1.4</android.version>
-    <android.version.platform>16</android.version.platform>
-  </properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-  <dependencies>
-    <dependency>
-      <artifactId>android</artifactId>
-      <version>${android.version}</version>
-      <groupId>com.google.android</groupId>
-      <scope>provided</scope>
-    </dependency>
+        <crouton.version>1.8.0-SNAPSHOT</crouton.version>
+        <android.version>4.1.1.4</android.version>
+        <android.version.platform>16</android.version.platform>
+    </properties>
 
-    <dependency>
-      <artifactId>crouton</artifactId>
-      <version>${crouton.version}</version>
-      <groupId>de.keyboardsurfer.android.widget</groupId>
-    </dependency>
+    <dependencies>
+        <dependency>
+            <artifactId>android</artifactId>
+            <version>${android.version}</version>
+            <groupId>com.google.android</groupId>
+            <scope>provided</scope>
+        </dependency>
 
-    <dependency>
-      <artifactId>crouton</artifactId>
-      <version>${crouton.version}</version>
-      <groupId>de.keyboardsurfer.android.widget</groupId>
-      <classifier>javadoc</classifier>
-    </dependency>
+        <dependency>
+            <artifactId>crouton</artifactId>
+            <version>${crouton.version}</version>
+            <groupId>de.keyboardsurfer.android.widget</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>crouton</artifactId>
+            <version>${crouton.version}</version>
+            <groupId>de.keyboardsurfer.android.widget</groupId>
+            <classifier>javadoc</classifier>
+        </dependency>
+        <dependency>
+            <artifactId>crouton</artifactId>
+            <version>${crouton.version}</version>
+            <groupId>de.keyboardsurfer.android.widget</groupId>
+            <classifier>sources</classifier>
+        </dependency>
 
-    <dependency>
-      <artifactId>crouton</artifactId>
-      <version>${crouton.version}</version>
-      <groupId>de.keyboardsurfer.android.widget</groupId>
-      <classifier>sources</classifier>
-    </dependency>
+        <dependency>
+            <groupId>com.actionbarsherlock</groupId>
+            <artifactId>actionbarsherlock</artifactId>
+            <version>4.2.0-SNAPSHOT</version>
+            <type>apklib</type>
+        </dependency>
 
-    <dependency>
-      <groupId>com.actionbarsherlock</groupId>
-      <artifactId>actionbarsherlock</artifactId>
-      <version>4.2.0</version>
-      <type>apklib</type>
-    </dependency>
+        <dependency>
+            <groupId>com.viewpagerindicator</groupId>
+            <artifactId>library</artifactId>
+            <version>2.4.1</version>
+            <type>apklib</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.android</groupId>
+                    <artifactId>support-v4</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
-    <dependency>
-      <groupId>com.viewpagerindicator</groupId>
-      <artifactId>library</artifactId>
-      <version>2.4.1</version>
-      <type>apklib</type>
-    </dependency>
+    </dependencies>
 
-  </dependencies>
+    <build>
+        <sourceDirectory>src</sourceDirectory>
 
-  <build>
-    <sourceDirectory>src</sourceDirectory>
-
-    <plugins>
-      <plugin>
-        <groupId>com.jayway.maven.plugins.android.generation2</groupId>
-        <artifactId>android-maven-plugin</artifactId>
-        <version>3.4.1</version>
-        <extensions>true</extensions>
-        <configuration>
-          <sdk>
-            <platform>${android.version.platform}</platform>
-          </sdk>
-          <undeployBeforeDeploy>true</undeployBeforeDeploy>
-          <lazyLibraryUnpack>true</lazyLibraryUnpack>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+        <plugins>
+            <plugin>
+                <groupId>com.jayway.maven.plugins.android.generation2</groupId>
+                <artifactId>android-maven-plugin</artifactId>
+                <version>3.4.1</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <sdk>
+                        <platform>${android.version.platform}</platform>
+                    </sdk>
+                    <undeployBeforeDeploy>true</undeployBeforeDeploy>
+                    <lazyLibraryUnpack>true</lazyLibraryUnpack>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/sample/project.properties
+++ b/sample/project.properties
@@ -12,6 +12,5 @@
 
 # Project target.
 target=android-16
-android.library.reference.1=../library
-android.library.reference.2=gen-external-apklibs/com.actionbarsherlock_actionbarsherlock_4.2.0
-android.library.reference.3=gen-external-apklibs/com.viewpagerindicator_library_2.4.1
+android.library.reference.1=gen-external-apklibs/com.actionbarsherlock_actionbarsherlock_4.2.0
+android.library.reference.2=gen-external-apklibs/com.viewpagerindicator_library_2.4.1

--- a/sample/src/de/keyboardsurfer/app/demo/crouton/CroutonFragment.java
+++ b/sample/src/de/keyboardsurfer/app/demo/crouton/CroutonFragment.java
@@ -26,6 +26,7 @@ import android.widget.AdapterView;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.Spinner;
+import de.keyboardsurfer.android.widget.crouton.Configuration;
 import de.keyboardsurfer.android.widget.crouton.Crouton;
 import de.keyboardsurfer.android.widget.crouton.Style;
 
@@ -35,9 +36,12 @@ import de.keyboardsurfer.android.widget.crouton.Style;
  */
 public class CroutonFragment extends Fragment implements AdapterView.OnItemSelectedListener, View.OnClickListener {
 
-  private static final Style INFINITE = new Style.Builder().
-    setBackgroundColorValue(Style.holoBlueLight).
-    setDuration(Style.DURATION_INFINITE).build();
+  private static final Style INFINITE = new Style.Builder()
+    .setBackgroundColorValue(Style.holoBlueLight)
+    .build();
+  private static final Configuration INFINITE_CONFIG = new Configuration.Builder()
+          .setDuration(Configuration.DURATION_INFINITE)
+          .build();
 
   private CheckBox displayOnTop;
   private Spinner styleSpinner;
@@ -123,7 +127,7 @@ public class CroutonFragment extends Fragment implements AdapterView.OnItemSelec
     Style croutonStyle = getSelectedStyleFromSpinner();
     String croutonText = getCroutonText();
 
-    showCrouton(croutonText, croutonStyle);
+    showCrouton(croutonText, croutonStyle, Configuration.DEFAULT);
   }
 
   private String getCroutonText() {
@@ -142,23 +146,24 @@ public class CroutonFragment extends Fragment implements AdapterView.OnItemSelec
     String croutonDurationString = getCroutonDurationString();
 
     if (TextUtils.isEmpty(croutonDurationString)) {
-      showCrouton(getString(R.string.warning_duration), Style.ALERT);
+      showCrouton(getString(R.string.warning_duration), Style.ALERT, Configuration.DEFAULT);
       return;
     }
 
     int croutonDuration = Integer.parseInt(croutonDurationString);
-    Style croutonStyle = new Style.Builder().setDuration(croutonDuration).build();
+    Style croutonStyle = new Style.Builder().build();
+    Configuration configuration = new Configuration.Builder().setDuration(croutonDuration).build();
 
     String croutonText = getCroutonText();
 
-    showCrouton(croutonText, croutonStyle);
+    showCrouton(croutonText, croutonStyle, configuration);
   }
 
   private String getCroutonDurationString() {
     return croutonDurationEdit.getText().toString().trim();
   }
 
-  private void showCrouton(String croutonText, Style croutonStyle) {
+  private void showCrouton(String croutonText, Style croutonStyle, Configuration configuration) {
     final boolean infinite = INFINITE == croutonStyle;
     
     if (infinite) {
@@ -174,7 +179,7 @@ public class CroutonFragment extends Fragment implements AdapterView.OnItemSelec
     if (infinite) {
       infiniteCrouton = crouton;
     }
-    crouton.setOnClickListener(this).show();
+    crouton.setOnClickListener(this).setConfiguration(infinite ? INFINITE_CONFIG : configuration).show();
   }
 
   @Override


### PR DESCRIPTION
Style is too limiting and the wrong name now. It contains aspects which should be available to none styled croutons.

Configuration file is dependant to Style/CustomView meaning we can set a duration on the Custom views!! Yay!

Please note, Only look at the last commit. I can cherry pick for you if you would like?

This now allows Crouton.make(Activity,View,ViewGroup, Config)
Or Crouton.make(Activity,View,ViewGroup).setConfiguration(Config.Builder().build()).show()

And of course added to showText Method so users can define non default config.

Feel free to ask questions. Or implement the concept slightly differently.

**Commit as follows**:
Separated out the Non Visual config from Style, Configuration is dependant of how the crouton is displayed.

Issue being the duration (and potentially other items) should not be tied to the Visual aspect.

Cherry Picked from upstream & master and merged.
