### PR TITLE
Fix: Use height of crouton view for animation (fixes #90)

### DIFF
--- a/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
@@ -513,7 +513,7 @@ public final class Crouton {
       if (getStyle().inAnimationResId > 0) {
         this.inAnimation = AnimationUtils.loadAnimation(getActivity(), getStyle().inAnimationResId);
       } else {
-        this.inAnimation = DefaultAnimationsBuilder.buildDefaultSlideInDownAnimation();
+        this.inAnimation = DefaultAnimationsBuilder.buildDefaultSlideInDownAnimation(getView());
       }
     }
 
@@ -525,7 +525,7 @@ public final class Crouton {
       if (getStyle().outAnimationResId > 0) {
         this.outAnimation = AnimationUtils.loadAnimation(getActivity(), getStyle().outAnimationResId);
       } else {
-        this.outAnimation = DefaultAnimationsBuilder.buildDefaultSlideOutUpAnimation();
+        this.outAnimation = DefaultAnimationsBuilder.buildDefaultSlideOutUpAnimation(getView());
       }
     }
 

--- a/library/src/de/keyboardsurfer/android/widget/crouton/DefaultAnimationsBuilder.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/DefaultAnimationsBuilder.java
@@ -17,6 +17,7 @@
 
 package de.keyboardsurfer.android.widget.crouton;
 
+import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.TranslateAnimation;
 
@@ -24,61 +25,41 @@ import android.view.animation.TranslateAnimation;
  * Builds the default animations for showing and hiding a {@link Crouton}.
  */
 final class DefaultAnimationsBuilder {
+  private static final long DURATION = 400;
   private static Animation slideInDownAnimation, slideOutUpAnimation;
-
-  protected static final class SlideInDownAnimationParameters {
-    private SlideInDownAnimationParameters() {
-      /* no-op */
-    }
-
-    public static final float FROM_X_DELTA = 0;
-    public static final float TO_X_DELTA = 0;
-    public static final float FROM_Y_DELTA = -50;
-    public static final float TO_Y_DELTA = 0;
-
-    public static final long DURATION = 400;
-  }
-
-  protected static final class SlideOutUpAnimationParameters {
-    private SlideOutUpAnimationParameters() {
-      /* no-op */
-    }
-
-    public static final float FROM_X_DELTA = 0;
-    public static final float TO_X_DELTA = 0;
-    public static final float FROM_Y_DELTA = 0;
-    public static final float TO_Y_DELTA = -50;
-
-    public static final long DURATION = 400;
-  }
 
   private DefaultAnimationsBuilder() {
     /* no-op */
   }
 
   /**
+   * @param croutonView
+   *   The croutonView which gets animated.
    * @return The default Animation for a showing {@link Crouton}.
    */
-  public static Animation buildDefaultSlideInDownAnimation() {
+  public static Animation buildDefaultSlideInDownAnimation(View croutonView) {
     if (null == slideInDownAnimation) {
-      slideInDownAnimation = new TranslateAnimation(SlideInDownAnimationParameters.FROM_X_DELTA,
-        SlideInDownAnimationParameters.TO_X_DELTA,
-        SlideInDownAnimationParameters.FROM_Y_DELTA, SlideInDownAnimationParameters.TO_Y_DELTA);
-      slideInDownAnimation.setDuration(SlideInDownAnimationParameters.DURATION);
+      slideInDownAnimation = new TranslateAnimation(
+        0, 0,                               // X: from, to
+        -croutonView.getMeasuredHeight(), 0 // Y: from, to
+      );
+      slideInDownAnimation.setDuration(DURATION);
     }
-
     return slideInDownAnimation;
   }
 
   /**
+   * @param croutonView
+   *   The croutonView which gets animated.
    * @return The default Animation for a hiding {@link Crouton}.
    */
-  public static Animation buildDefaultSlideOutUpAnimation() {
+  public static Animation buildDefaultSlideOutUpAnimation(View croutonView) {
     if (null == slideOutUpAnimation) {
-      slideOutUpAnimation = new TranslateAnimation(SlideOutUpAnimationParameters.FROM_X_DELTA,
-        SlideOutUpAnimationParameters.TO_X_DELTA,
-        SlideOutUpAnimationParameters.FROM_Y_DELTA, SlideOutUpAnimationParameters.TO_Y_DELTA);
-      slideOutUpAnimation.setDuration(SlideOutUpAnimationParameters.DURATION);
+      slideOutUpAnimation = new TranslateAnimation(
+        0, 0,                               // X: from, to
+        0, -croutonView.getMeasuredHeight() // Y: from, to
+      );
+      slideOutUpAnimation.setDuration(DURATION);
     }
     return slideOutUpAnimation;
   }

--- a/library/src/de/keyboardsurfer/android/widget/crouton/Manager.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Manager.java
@@ -26,6 +26,7 @@ import android.support.v4.view.accessibility.AccessibilityEventCompat;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.view.ViewTreeObserver;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.widget.FrameLayout;
@@ -182,13 +183,13 @@ final class Manager extends Handler {
    * @param crouton
    *   The {@link Crouton} that should be added.
    */
-  private void addCroutonToView(Crouton crouton) {
+  private void addCroutonToView(final Crouton crouton) {
     // don't add if it is already showing
     if (crouton.isShowing()) {
       return;
     }
 
-    View croutonView = crouton.getView();
+    final View croutonView = crouton.getView();
     if (null == croutonView.getParent()) {
       ViewGroup.LayoutParams params = croutonView.getLayoutParams();
       if (null == params) {
@@ -210,12 +211,25 @@ final class Manager extends Handler {
         activity.addContentView(croutonView, params);
       }
     }
-    croutonView.startAnimation(crouton.getInAnimation());
-    announceForAccessibilityCompat(crouton.getActivity(), crouton.getText());
-    if (Style.DURATION_INFINITE != crouton.getStyle().durationInMilliseconds) {
-      sendMessageDelayed(crouton, Messages.REMOVE_CROUTON,
-        crouton.getStyle().durationInMilliseconds + crouton.getInAnimation().getDuration());
-    }
+
+    croutonView.requestLayout(); // This is needed so the animation can use the measured with/height
+    croutonView.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+      @Override
+      public void onGlobalLayout() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+          croutonView.getViewTreeObserver().removeGlobalOnLayoutListener(this);
+        } else {
+          croutonView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+        }
+
+        croutonView.startAnimation(crouton.getInAnimation());
+        announceForAccessibilityCompat(crouton.getActivity(), crouton.getText());
+        if (Style.DURATION_INFINITE != crouton.getStyle().durationInMilliseconds) {
+          sendMessageDelayed(crouton, Messages.REMOVE_CROUTON,
+                crouton.getStyle().durationInMilliseconds + crouton.getInAnimation().getDuration());
+        }
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
This fixes #90 and works with custom views as well.

I cleaned up some code (in my opinion). Not sure if you are okay with me removing those two inner classes (SlideInDownAnimationParameters and SlideOutUpAnimationParameters). I thought they were too much for the purpose. I added comments instead to show what the values stand for.

Let me know if you do not like it and prefer to have those two classes back.
