### PR TITLE
Sample: Add a custom view sample

### DIFF
--- a/sample/res/layout/crouton_custom_view.xml
+++ b/sample/res/layout/crouton_custom_view.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:background="@drawable/abs__list_selector_background_transition_holo_light"
+    android:padding="10dp">
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_launcher" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_marginLeft="5dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textColor="#fff"
+            android:text="@string/custom_title"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="#fff"
+            android:text="@string/custom_message" />
+    </LinearLayout>
+</LinearLayout>

--- a/sample/res/values/strings.xml
+++ b/sample/res/values/strings.xml
@@ -35,4 +35,7 @@
   <string name="feedback">Feel free to provide feedback (bugs, etc) and pull requests on %1$s. Also further documentation is available there.</string>
   <string name="attributions">This app uses software licensed under the %1$s. Further information can be seen in the app\'s source code on %2$s.</string>
   <string name="infinity_text">This Crouton will be visible until you click on it or rotate the device.</string>
+
+  <string name="custom_title">Title</string>
+  <string name="custom_message">Hello World!</string>
 </resources>

--- a/sample/res/values/style_entries.xml
+++ b/sample/res/values/style_entries.xml
@@ -22,8 +22,9 @@
 		<item>Alert</item>
 		<item>Confirm</item>
 		<item>Info</item>
-    <item>Infinite</item>
-		<item>Custom</item>
+		<item>Infinite</item>
+		<item>Custom Style</item>
+		<item>Custom View</item>
 	</string-array>
 
 </resources>

--- a/sample/src/de/keyboardsurfer/app/demo/crouton/CroutonFragment.java
+++ b/sample/src/de/keyboardsurfer/app/demo/crouton/CroutonFragment.java
@@ -90,7 +90,11 @@ public class CroutonFragment extends Fragment implements AdapterView.OnItemSelec
     if (croutonStyle != null) {
       showNonCustomCrouton();
     } else {
-      showCustomCrouton();
+      if (styleSpinner.getSelectedItemId() == 4) {
+        showCustomCrouton();
+      } else {
+        showCustomViewCrouton();
+      }
     }
   }
 
@@ -154,6 +158,17 @@ public class CroutonFragment extends Fragment implements AdapterView.OnItemSelec
     showCrouton(croutonText, croutonStyle);
   }
 
+  private void showCustomViewCrouton() {
+    View view = getLayoutInflater(null).inflate(R.layout.crouton_custom_view, null);
+    final Crouton crouton;
+    if (displayOnTop.isChecked()) {
+      crouton = Crouton.make(getActivity(), view);
+    } else {
+      crouton = Crouton.make(getActivity(), view, R.id.alternate_view_group);
+    }
+    crouton.show();
+  }
+
   private String getCroutonDurationString() {
     return croutonDurationEdit.getText().toString().trim();
   }
@@ -180,12 +195,13 @@ public class CroutonFragment extends Fragment implements AdapterView.OnItemSelec
   @Override
   public void onItemSelected(AdapterView<?> adapterView, View view, int position, long id) {
     switch ((int) id) {
-      case 3: {
+      case 3:   // Infinite
+      case 5: { // Custom View
         croutonTextEdit.setVisibility(View.GONE);
         croutonDurationEdit.setVisibility(View.GONE);
         break;
       }
-      case 4: {
+      case 4: { // Custom Style
         croutonDurationEdit.setVisibility(View.VISIBLE);
         break;
       }


### PR DESCRIPTION
This just adds a custom view sample.

The animation of the custom view is messed up. But this is fixed with the other pull request I sent.

As well it currently does not fill the width. I thought Crouton by default sets the LayoutParams width to MATCH_PARENT, but maybe not here. Will investigate and send another pull request when fixed.
