### PR TITLE
Fix: Custom views should have MATCH_PARENT as default width

### DIFF
--- a/library/src/de/keyboardsurfer/android/widget/crouton/Manager.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Manager.java
@@ -192,7 +192,7 @@ final class Manager extends Handler {
     if (null == croutonView.getParent()) {
       ViewGroup.LayoutParams params = croutonView.getLayoutParams();
       if (null == params) {
-        params = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        params = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
       }
       // display Crouton in ViewGroup is it has been supplied
       if (null != crouton.getViewGroup()) {


### PR DESCRIPTION
I was expecting that custom views without LayoutParams will receive MATCH_PARENT for their width. This seems to not be the case in the current implementation.
Of course one can fix this by inflating it correctly. But for that the parent view needs to be available. Or one can just set the LayoutParams. Both not a big problem. But I think the default should be MATCH_PARENT.

About breaking previous custom views. I doubt anyone really used custom views, since there are many problems with them (see my other pull requests). Specially the inability to set duration on custom views makes them come and disappear without enough time to read them.
