### PR TITLE
included a proper uses-sdk tag

### DIFF
--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -19,7 +19,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.keyboardsurfer.mobile.app.android.widget.crouton"
     android:versionCode="1"
-    android:versionName="1.7" 
-    android:minSdkVersion="4">
+    android:versionName="1.7">
+    
+    <uses-sdk android:minSdkVersion="4" />
 
 </manifest>


### PR DESCRIPTION
The value `android:minSdkVersion`, when inside the manifest tag, is invalid, but instead of generating errors, it will silently ignore the otherwise unknown property. Without uses-sdk, the project behaves as an SDK version 1 (Android 1.0) project.
