### PR TITLE
getLicense method is not accessible

### DIFF
--- a/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
@@ -545,7 +545,7 @@ public final class Crouton {
    * @return 
    *     The license text.
    */
-  public String getLicenseText() {
+  public static String getLicenseText() {
     return "This application uses the Crouton library.\n\n" +
       "Copyright 2012 - 2013 Benjamin Weiss \n" +
       "Copyright 2012 Neofonie Mobile GmbH\n" +


### PR DESCRIPTION
The getLicense method is now static to allow dev to get the license without a Crouton instance.
