### PR TITLE
Force Crouton measure() before creating animation

### DIFF
--- a/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
@@ -530,6 +530,7 @@ public final class Crouton {
       if (getStyle().inAnimationResId > 0) {
         this.inAnimation = AnimationUtils.loadAnimation(getActivity(), getStyle().inAnimationResId);
       } else {
+        measureCroutonView();
         this.inAnimation = DefaultAnimationsBuilder.buildDefaultSlideInDownAnimation(getView());
       }
     }
@@ -675,6 +676,19 @@ public final class Crouton {
     }
 
     return croutonView;
+  }
+
+  private void measureCroutonView() {
+      View view = getView();
+      int widthSpec;
+      if (viewGroup != null) {
+        widthSpec = View.MeasureSpec.makeMeasureSpec(viewGroup.getMeasuredWidth(), View.MeasureSpec.AT_MOST);
+      } else {
+        widthSpec = View.MeasureSpec.makeMeasureSpec(activity.getWindow().getDecorView().getMeasuredWidth(),
+                  View.MeasureSpec.AT_MOST);
+      }
+
+      view.measure(widthSpec, View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED));
   }
 
   private void initializeCroutonView() {

--- a/library/src/de/keyboardsurfer/android/widget/crouton/DefaultAnimationsBuilder.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/DefaultAnimationsBuilder.java
@@ -38,13 +38,11 @@ final class DefaultAnimationsBuilder {
    * @return The default Animation for a showing {@link Crouton}.
    */
   public static Animation buildDefaultSlideInDownAnimation(View croutonView) {
-    if (null == slideInDownAnimation) {
-      slideInDownAnimation = new TranslateAnimation(
-        0, 0,                               // X: from, to
-        -croutonView.getMeasuredHeight(), 0 // Y: from, to
-      );
-      slideInDownAnimation.setDuration(DURATION);
-    }
+    slideInDownAnimation = new TranslateAnimation(
+      0, 0,                               // X: from, to
+      -croutonView.getMeasuredHeight(), 0 // Y: from, to
+    );
+    slideInDownAnimation.setDuration(DURATION);
     return slideInDownAnimation;
   }
 
@@ -54,13 +52,11 @@ final class DefaultAnimationsBuilder {
    * @return The default Animation for a hiding {@link Crouton}.
    */
   public static Animation buildDefaultSlideOutUpAnimation(View croutonView) {
-    if (null == slideOutUpAnimation) {
-      slideOutUpAnimation = new TranslateAnimation(
-        0, 0,                               // X: from, to
-        0, -croutonView.getMeasuredHeight() // Y: from, to
-      );
-      slideOutUpAnimation.setDuration(DURATION);
-    }
+    slideOutUpAnimation = new TranslateAnimation(
+      0, 0,                               // X: from, to
+      0, -croutonView.getMeasuredHeight() // Y: from, to
+    );
+    slideOutUpAnimation.setDuration(DURATION);
     return slideOutUpAnimation;
   }
 }


### PR DESCRIPTION
Force Crouton view to measure first so that animation is smooth if it's more than one line. Also not caching animation to handle the case where Crouton view heights are different from one Crouton to the next.

To see this in action, create a Crouton with really long text that will force it to wrap two lines, then call Crouton.makeText(activity, reallyReallyLongString, Style.INFO).show();

The animation will start with part of the view exposed and end before the bottom fully animates off the screen.
