### PR TITLE
Fix bug 112 - Gravity incorrectly applied

### DIFF
--- a/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
@@ -26,6 +26,7 @@ import android.graphics.Shader;
 import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
 import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
@@ -821,7 +822,7 @@ public final class Crouton {
   private RelativeLayout initializeContentView(final Resources resources) {
     RelativeLayout contentView = new RelativeLayout(this.activity);
     contentView.setLayoutParams(new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT,
-      RelativeLayout.LayoutParams.WRAP_CONTENT));
+      RelativeLayout.LayoutParams.MATCH_PARENT));
 
     // set padding
     int padding = this.style.paddingInPixels;
@@ -847,6 +848,11 @@ public final class Crouton {
     if (null != image) {
       textParams.addRule(RelativeLayout.RIGHT_OF, image.getId());
     }
+    
+    if (this.style.gravity == Gravity.CENTER) textParams.addRule(RelativeLayout.CENTER_IN_PARENT);
+    else if (this.style.gravity == Gravity.CENTER_VERTICAL) textParams.addRule(RelativeLayout.CENTER_VERTICAL);
+    else if (this.style.gravity == Gravity.CENTER_HORIZONTAL) textParams.addRule(RelativeLayout.CENTER_HORIZONTAL);
+
     contentView.addView(text, textParams);
     return contentView;
   }


### PR DESCRIPTION
- The Gravity attribute is currently applied on the TextView inside the contentView, a RelativeLayout. The TextView is the same height as the RelativeLayout, so it appears as though vertical Gravity settings (CENTER, CENTER_VERTICAL) aren't being applied correctly
- I changed it so that the RelativeLayout fills the croutonView, and also adds a layout rule based on the Gravity attribute. Now the RelativeLayout and FrameLayout are the same dimensions, but the TextView is full width, and wrap content for height, so it's able to use the RL rules for vertical positioning and as before with horizontal positioning.
- The fix only works with CENTER, CENTER_HORIZONTAL, and CENTER_VERTICAL; it hasn't been tested with RIGHT, LEFT etc.

---

Please let me know how I can improve my pull requests.
