### PR TITLE
Accessibility update; ViewGroup positioning; DownUnder mode for default in & out animations.

### DIFF
--- a/library/src/de/keyboardsurfer/android/widget/crouton/Configuration.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Configuration.java
@@ -37,6 +37,16 @@ public class Configuration {
   public static final int DURATION_SHORT = 3000;
   /** The default long display duration of a {@link Crouton}. */
   public static final int DURATION_LONG = 5000;
+  
+  /** The default start position of a {@link Crouton} within the potentially specified ViewGroup. */
+  public static final int POSITION_START = 0;
+  /** The default middle position of a {@link Crouton} within the potentially specified ViewGroup. */
+  public static final int POSITION_MIDDLE = -1;
+  /** The default end position of a {@link Crouton} within the potentially specified ViewGroup. */
+  public static final int POSITION_END = Integer.MAX_VALUE;
+  /** Special code that can be used for inAnimationResId or outAnimationResId to yield a DownUnder
+   *  version of their respective animations. See {@link Crouton}. */
+  public static final int ANIMMODE_DOWNUNDER = -1;	//assuming -1 will never be a valid resource
 
   /** The default {@link Configuration} of a {@link Crouton}. */
   public static final Configuration DEFAULT;
@@ -51,11 +61,14 @@ public class Configuration {
   final int inAnimationResId;
   /** The resource id for the out animation. */
   final int outAnimationResId;
+  /** The position within the possibly specified viewGroup. */
+  final int viewGroupPosition;
 
   private Configuration(Builder builder) {
     this.durationInMilliseconds = builder.durationInMilliseconds;
     this.inAnimationResId = builder.inAnimationResId;
     this.outAnimationResId = builder.outAnimationResId;
+    this.viewGroupPosition = builder.viewGroupPosition;
   }
 
   /** Creates a {@link Builder} to build a {@link Configuration} upon. */
@@ -63,13 +76,14 @@ public class Configuration {
     private int durationInMilliseconds = DURATION_SHORT;
     private int inAnimationResId = 0;
     private int outAnimationResId = 0;
+    private int viewGroupPosition = POSITION_START;
 
     /**
      * Set the durationInMilliseconds option of the {@link Crouton}.
      *
      * @param duration
-     *   The durationInMilliseconds the crouton will be displayed
-     *   {@link Crouton} in milliseconds.
+     *   The durationInMilliseconds the {@link Crouton} will be displayed
+     *   in milliseconds.
      *
      * @return the {@link Builder}.
      */
@@ -110,6 +124,24 @@ public class Configuration {
     }
 
     /**
+     * The integer position that the {@link Crouton} should be displayed at
+     * within the specified ViewGroup.
+     * If the position given exceeds the maximum positions actually available
+     * within the ViewGroup at the moment of display, then the position will
+     * be forced to the last position available.
+     *
+     * @param viewGroupPosition
+     *   The integer position that the {@link Crouton} should be displayed at
+     *   within the specified ViewGroup.
+     *
+     * @return the {@link Builder}.
+     */
+    public Builder setViewGroupPosition(final int viewGroupPosition) {
+      this.viewGroupPosition = viewGroupPosition;
+
+      return this;
+    }
+    /**
      * Builds the {@link Configuration}.
      *
      * @return The built {@link Configuration}.
@@ -125,6 +157,7 @@ public class Configuration {
       "durationInMilliseconds=" + durationInMilliseconds +
       ", inAnimationResId=" + inAnimationResId +
       ", outAnimationResId=" + outAnimationResId +
+      ", viewGroupPosition=" + viewGroupPosition +
       '}';
   }
 }

--- a/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/Crouton.java
@@ -574,7 +574,12 @@ public final class Crouton {
         this.inAnimation = AnimationUtils.loadAnimation(getActivity(), getConfiguration().inAnimationResId);
       } else {
         measureCroutonView();
-        this.inAnimation = DefaultAnimationsBuilder.buildDefaultSlideInDownAnimation(getView());
+        //Apply DownUnder feature if POSITION_END used or ANIMMODE_DOWNUNDER used
+        if(getConfiguration().viewGroupPosition == Configuration.POSITION_END || getConfiguration().inAnimationResId == Configuration.ANIMMODE_DOWNUNDER) {
+        	this.inAnimation = DefaultAnimationsBuilder.buildDefaultSlideInDownAnimation(getView(), true);
+        } else {
+        	this.inAnimation = DefaultAnimationsBuilder.buildDefaultSlideInDownAnimation(getView());
+        }
       }
     }
 
@@ -586,7 +591,12 @@ public final class Crouton {
       if (getConfiguration().outAnimationResId > 0) {
         this.outAnimation = AnimationUtils.loadAnimation(getActivity(), getConfiguration().outAnimationResId);
       } else {
-        this.outAnimation = DefaultAnimationsBuilder.buildDefaultSlideOutUpAnimation(getView());
+    	//Apply DownUnder feature if POSITION_END used or ANIMMODE_DOWNUNDER used
+      	if(getConfiguration().viewGroupPosition == Configuration.POSITION_END || getConfiguration().inAnimationResId == Configuration.ANIMMODE_DOWNUNDER) {
+        	this.outAnimation = DefaultAnimationsBuilder.buildDefaultSlideOutUpAnimation(getView(), true);
+        } else {
+            this.outAnimation = DefaultAnimationsBuilder.buildDefaultSlideOutUpAnimation(getView());
+        }
       }
     }
 

--- a/library/src/de/keyboardsurfer/android/widget/crouton/DefaultAnimationsBuilder.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/DefaultAnimationsBuilder.java
@@ -38,10 +38,27 @@ final class DefaultAnimationsBuilder {
    * @return The default Animation for a showing {@link Crouton}.
    */
   static Animation buildDefaultSlideInDownAnimation(View croutonView) {
+    return buildDefaultSlideInDownAnimation(croutonView, false);
+  }
+  
+  /**
+   * @param croutonView
+   *   The croutonView which gets animated.
+   * @param isDownUnder
+   *   True if the Crouton should animate in and out opposite to the "normal" way.
+   *   This will in fact yield a Crouton that animates-in in an upwardly fashion,
+   *   animates out in a downward fashion, and thus behaves more like its real-world
+   *   counterpart bobbing up in a bowl of soup and then sinking down. Also note that
+   *   water spins in the opposite direction in the southern hemisphere.
+   *
+   * @return The default Animation for a showing {@link Crouton}.
+   */
+  static Animation buildDefaultSlideInDownAnimation(View croutonView, boolean isDownUnder) {
     if (!areLastMeasuredInAnimationHeightAndCurrentEqual(croutonView) || (null == slideInDownAnimation)) {
+    	int directionAdjust = (isDownUnder)? 1 : -1;
       slideInDownAnimation = new TranslateAnimation(
         0, 0,                               // X: from, to
-        -croutonView.getMeasuredHeight(), 0 // Y: from, to
+        directionAdjust * croutonView.getMeasuredHeight(), 0 // Y: from, to
       );
       slideInDownAnimation.setDuration(DURATION);
       setLastInAnimationHeight(croutonView.getMeasuredHeight());
@@ -56,10 +73,21 @@ final class DefaultAnimationsBuilder {
    * @return The default Animation for a hiding {@link Crouton}.
    */
   static Animation buildDefaultSlideOutUpAnimation(View croutonView) {
+    return buildDefaultSlideOutUpAnimation(croutonView, false);
+  }
+  
+  /**
+   * @param croutonView
+   *   The croutonView which gets animated.
+   *
+   * @return The default Animation for a hiding {@link Crouton}.
+   */
+  static Animation buildDefaultSlideOutUpAnimation(View croutonView, boolean isDownUnder) {
     if (!areLastMeasuredOutAnimationHeightAndCurrentEqual(croutonView) || (null == slideOutUpAnimation)) {
+    	int directionAdjust = (isDownUnder)? 1 : -1;
       slideOutUpAnimation = new TranslateAnimation(
         0, 0,                               // X: from, to
-        0, -croutonView.getMeasuredHeight() // Y: from, to
+        0, directionAdjust * croutonView.getMeasuredHeight() // Y: from, to
       );
       slideOutUpAnimation.setDuration(DURATION);
       setLastOutAnimationHeight(croutonView.getMeasuredHeight());

--- a/library/src/de/keyboardsurfer/android/widget/crouton/LifecycleCallback.java
+++ b/library/src/de/keyboardsurfer/android/widget/crouton/LifecycleCallback.java
@@ -24,5 +24,5 @@ public interface LifecycleCallback {
   /** Will be called when your {@link Crouton} has been removed. */
   public void onRemoved();
 
-  //public void onCeasarDressing();
+  //public void onCaesarDressing();
 }


### PR DESCRIPTION
- The Accessibility feature wasn't working in JB, added a fix for JB ontop of the legacy method.
- Added means to specify positions (start, middle, end) to place Crouton in a ViewGroup.
- Updated DefaultAnimationsBuilder to provide an in animation that slides up and out animation that slides which is used when the Crouton is at the end^ position of ViewGroup OR DownUnderMode flag is set for in or out animations.
  
  ^ that might not be desirable for all cases, perhaps DownUnder mode should only be applied if DownUnderMode flag is specifically set for animations?

Also note: I haven't tested the new features with multi-line Croutons.
