### PR TITLE
Fixed default crouton position when using translucent status bar.

### DIFF
--- a/library/src/main/java/de/keyboardsurfer/android/widget/crouton/Manager.java
+++ b/library/src/main/java/de/keyboardsurfer/android/widget/crouton/Manager.java
@@ -18,6 +18,7 @@ package de.keyboardsurfer.android.widget.crouton;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.Resources;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Message;
@@ -26,6 +27,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.view.ViewTreeObserver;
+import android.view.WindowManager;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.widget.FrameLayout;
@@ -207,6 +209,22 @@ final class Manager extends Handler {
         Activity activity = crouton.getActivity();
         if (null == activity || activity.isFinishing()) {
           return;
+        }
+        // Translucent status is only available as of Android 4.4 Kit Kat.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            int flags = activity.getWindow().getAttributes().flags;
+            int translucentStatusFlag = WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS;
+            /* Checks whether translucent status is enabled for this window.
+            * If true, sets the top margin to show the crouton just below the action bar. */
+            if ((flags & translucentStatusFlag) == translucentStatusFlag) {
+                int actionBarContainerId = Resources.getSystem().getIdentifier("action_bar_container", "id", "android");
+                View actionBarContainer = activity.findViewById(actionBarContainerId);
+                // The action bar is present: the app is using a Holo theme.
+                if (actionBarContainer != null) {
+                    ViewGroup.MarginLayoutParams marginParams = (ViewGroup.MarginLayoutParams) params;
+                    marginParams.topMargin = actionBarContainer.getBottom();
+                }
+            }
         }
         activity.addContentView(croutonView, params);
       }


### PR DESCRIPTION
Fixes #142

This fix forces croutons to be shown below the action bar or tabs (if any) when the translucent status bar feature introduced in Android 4.4 Kit Kat is enabled. This solution relies on the presence of the internal action bar container view. It's not as elegant as I'd like to, but I'm quite convinced there's no other way to do it. If no action bar is present (e.g.: the app is not using a Holo theme), they'll be shown at the same place of the prior implementation.

[This screenshot](http://i.imgur.com/X7olMLf.png) illustrates a crouton correctly being shown when the translucent status bar is enabled.
