### PR TITLE
Fix occasional null pointer when accessing the context

### DIFF
--- a/library/src/main/java/de/keyboardsurfer/android/widget/crouton/Manager.java
+++ b/library/src/main/java/de/keyboardsurfer/android/widget/crouton/Manager.java
@@ -411,9 +411,12 @@ final class Manager extends Handler {
    */
   public static void announceForAccessibilityCompat(Context context, CharSequence text) {
     if (Build.VERSION.SDK_INT >= 4) {
-      AccessibilityManager accessibilityManager = (AccessibilityManager) context.getSystemService(
-          Context.ACCESSIBILITY_SERVICE);
-      if (!accessibilityManager.isEnabled()) {
+      AccessibilityManager accessibilityManager = null;
+      if (context != null) {
+        accessibilityManager = (AccessibilityManager) context.getSystemService(
+            Context.ACCESSIBILITY_SERVICE);
+      }
+      if (accessibilityManager == null || !accessibilityManager.isEnabled()) {
         return;
       }
 


### PR DESCRIPTION
Implements a fix for issue #148 Null pointer exception in Manager#announceForAccessibilityCompat
