### PR TITLE
Switch setLifecycleCallback setter for Croutons to use a fluent interface

### DIFF
--- a/library/src/main/java/de/keyboardsurfer/android/widget/crouton/Crouton.java
+++ b/library/src/main/java/de/keyboardsurfer/android/widget/crouton/Crouton.java
@@ -601,9 +601,12 @@ public final class Crouton {
   /**
    * @param lifecycleCallback
    *     Callback object for notable events in the life of a Crouton.
+   *
+   * @return this {@link Crouton}.
    */
-  public void setLifecycleCallback(LifecycleCallback lifecycleCallback) {
+  public Crouton setLifecycleCallback(LifecycleCallback lifecycleCallback) {
     this.lifecycleCallback = lifecycleCallback;
+    return this;
   }
 
   /**


### PR DESCRIPTION
This will allow the lifecycle callback setter to be chained into a Crouton creation statement like the setOnClickListener and setConfiguration already are.