### PR TITLE
Update README for newest Version

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -105,7 +105,7 @@ Then declare Crouton within your dependencies:
 ```groovy
 dependencies {
   ...
-  compile('de.keyboardsurfer.android.widget:crouton:1.8.4') {
+  compile('de.keyboardsurfer.android.widget:crouton:+') {
     // exclusion is not neccessary, but generally a good idea.
     exclude group: 'com.google.android', module: 'support-v4'
   }


### PR DESCRIPTION
Always bring up the new version of Crouton in gradle 
and, compile('de.keyboardsurfer.android.widget:crouton:1.8.4') has old android support v4 library. so it can't use SwipeRefreshLayout.
