### PR TITLE
Fixed memory leak in DefaultAnimationsBuilder

### DIFF
--- a/library/src/main/java/de/keyboardsurfer/android/widget/crouton/DefaultAnimationsBuilder.java
+++ b/library/src/main/java/de/keyboardsurfer/android/widget/crouton/DefaultAnimationsBuilder.java
@@ -23,8 +23,6 @@ import android.view.animation.TranslateAnimation;
 /** Builds the default animations for showing and hiding a {@link Crouton}. */
 final class DefaultAnimationsBuilder {
   private static final long DURATION = 400;
-  private static Animation slideInDownAnimation, slideOutUpAnimation;
-  private static int lastInAnimationHeight, lastOutAnimationHeight;
 
   private DefaultAnimationsBuilder() {
     /* no-op */
@@ -37,14 +35,11 @@ final class DefaultAnimationsBuilder {
    * @return The default Animation for a showing {@link Crouton}.
    */
   static Animation buildDefaultSlideInDownAnimation(View croutonView) {
-    if (!areLastMeasuredInAnimationHeightAndCurrentEqual(croutonView) || (null == slideInDownAnimation)) {
-      slideInDownAnimation = new TranslateAnimation(
-        0, 0,                               // X: from, to
-        -croutonView.getMeasuredHeight(), 0 // Y: from, to
-      );
-      slideInDownAnimation.setDuration(DURATION);
-      setLastInAnimationHeight(croutonView.getMeasuredHeight());
-    }
+    Animation slideInDownAnimation = new TranslateAnimation(
+      0, 0,                               // X: from, to
+      -croutonView.getMeasuredHeight(), 0 // Y: from, to
+    );
+    slideInDownAnimation.setDuration(DURATION);
     return slideInDownAnimation;
   }
 
@@ -55,34 +50,12 @@ final class DefaultAnimationsBuilder {
    * @return The default Animation for a hiding {@link Crouton}.
    */
   static Animation buildDefaultSlideOutUpAnimation(View croutonView) {
-    if (!areLastMeasuredOutAnimationHeightAndCurrentEqual(croutonView) || (null == slideOutUpAnimation)) {
-      slideOutUpAnimation = new TranslateAnimation(
-        0, 0,                               // X: from, to
-        0, -croutonView.getMeasuredHeight() // Y: from, to
-      );
-      slideOutUpAnimation.setDuration(DURATION);
-      setLastOutAnimationHeight(croutonView.getMeasuredHeight());
-    }
+    Animation slideOutUpAnimation = new TranslateAnimation(
+      0, 0,                               // X: from, to
+      0, -croutonView.getMeasuredHeight() // Y: from, to
+    );
+    slideOutUpAnimation.setDuration(DURATION);
     return slideOutUpAnimation;
   }
 
-  private static boolean areLastMeasuredInAnimationHeightAndCurrentEqual(View croutonView) {
-    return areLastMeasuredAnimationHeightAndCurrentEqual(lastInAnimationHeight, croutonView);
-  }
-
-  private static boolean areLastMeasuredOutAnimationHeightAndCurrentEqual(View croutonView) {
-    return areLastMeasuredAnimationHeightAndCurrentEqual(lastOutAnimationHeight, croutonView);
-  }
-
-  private static boolean areLastMeasuredAnimationHeightAndCurrentEqual(int lastHeight, View croutonView) {
-    return lastHeight == croutonView.getMeasuredHeight();
-  }
-
-  private static void setLastInAnimationHeight(int lastInAnimationHeight) {
-    DefaultAnimationsBuilder.lastInAnimationHeight = lastInAnimationHeight;
-  }
-
-  private static void setLastOutAnimationHeight(int lastOutAnimationHeight) {
-    DefaultAnimationsBuilder.lastOutAnimationHeight = lastOutAnimationHeight;
-  }
 }


### PR DESCRIPTION
When the animations get run there is a Handler that gets set on the Animation (Animation.mListenerHandler). This Handler holds a reference to the Activity. So caching the animations in a static field causes the Activity to be leaked. The fix was to remove the static fields that were caching the animation. Now the animations are created new each time.
